### PR TITLE
feat(1.2): CLI entry point with Commander.js (plaid wiki)

### DIFF
--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -16,3 +16,6 @@
 - [2026-04-09T19:03:17.675Z] [commander] cycle=6 action=execute-task summary=Completed task 1.1 (Initialize TypeScript project): created package.json, tsconfig, tsup, vitest, CI workflow, placeholder CLI entry point. Build/test/lint all pass. Opened PR #7.
 - [2026-04-09T19:04:34Z] [commander] cycle=cycle-1 action=process-issue summary=Processed issue #6 (rename CLI to plaid wiki): labeled, commented, updated task 1.2 in plan.yaml.
 - [2026-04-09T19:14:00Z] [commander] cycle=cycle-1 action=merge-pr summary=Resolved merge conflict in activity-log.md, merged PR #7 (feat(1.1): initialize TypeScript project) via squash merge. Task 1.1 complete. Branch deleted.
+- [2026-04-09T19:17:02.693Z] [commander] cycle=9 action=merge-pr summary=Resolved merge conflict in activity-log.md and merged PR #7 (feat(1.1): initialize TypeScript project) via squash merge. Task 1.1 complete.
+- [2026-04-09T19:23:26.067Z] [commander] cycle=10 action=execute-task summary=Started task 1.2 (CLI entry point with Commander.js) — delegated to gem-orchestrator on branch task/cycle-1/1.2
+- [2026-04-09T19:25:45Z] [commander] cycle=cycle-1 action=execute-task task=1.2 summary=Completed task 1.2: CLI entry point with Commander.js. Opened PR #8.

--- a/docs/state.json
+++ b/docs/state.json
@@ -6,7 +6,7 @@
   "started_at": "2026-04-09T18:41:00Z",
   "tasks": {
     "1.1": { "status": "completed", "attempts": 1, "pr": 7 },
-    "1.2": { "status": "pending", "attempts": 0 },
+    "1.2": { "status": "completed", "attempts": 1, "pr": 8 },
     "2.1": { "status": "pending", "attempts": 0 },
     "2.2": { "status": "pending", "attempts": 0 },
     "2.3": { "status": "pending", "attempts": 0 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "llmwiki",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3"
+      },
       "bin": {
         "llmwiki": "dist/cli.js"
       },
@@ -1028,12 +1031,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "engines": {
-        "node": ">= 6"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -1554,6 +1556,15 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/thenify": {
@@ -2467,10 +2478,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
     },
     "confbox": {
       "version": "0.1.8",
@@ -2825,6 +2835,14 @@
         "pirates": "^4.0.1",
         "tinyglobby": "^0.2.11",
         "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
       }
     },
     "thenify": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A personal knowledge base where the LLM does all the maintenance",
   "type": "module",
   "bin": {
-    "llmwiki": "./dist/cli.js"
+    "plaid": "./dist/cli.js"
   },
   "scripts": {
     "build": "tsup",
@@ -12,15 +12,23 @@
     "lint": "tsc --noEmit",
     "dev": "vitest watch"
   },
-  "keywords": ["wiki", "knowledge-base", "cli", "llm"],
+  "keywords": [
+    "wiki",
+    "knowledge-base",
+    "cli",
+    "llm"
+  ],
   "license": "MIT",
   "engines": {
     "node": ">=20"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
+    "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
-    "vitest": "^3.0.0",
-    "@types/node": "^20.0.0"
+    "typescript": "^5.4.0",
+    "vitest": "^3.0.0"
+  },
+  "dependencies": {
+    "commander": "^14.0.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,1 +1,49 @@
-console.log("llmwiki CLI — not yet implemented");
+import { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8')
+);
+
+export function createProgram(): Command {
+  const program = new Command();
+
+  program
+    .name('plaid')
+    .description('Plaid CLI — modular developer toolkit')
+    .version(pkg.version);
+
+  const wiki = program
+    .command('wiki')
+    .description('Personal knowledge base powered by LLM')
+    .option('--json', 'Output results as JSON', false);
+
+  const subcommands = ['init', 'ingest', 'query', 'lint', 'status'] as const;
+
+  for (const name of subcommands) {
+    wiki
+      .command(name)
+      .description(`${name} — not yet implemented`)
+      .action((_options: unknown, cmd: Command) => {
+        const jsonMode = cmd.parent?.opts().json ?? false;
+        if (jsonMode) {
+          console.log(JSON.stringify({ error: 'not yet implemented' }));
+        } else {
+          console.log(`${name}: not yet implemented`);
+        }
+      });
+  }
+
+  return program;
+}
+
+const program = createProgram();
+
+if (resolve(process.argv[1] ?? '') === __filename) {
+  program.parse(process.argv);
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { createProgram } from '../../src/cli.js';
+
+describe('CLI', () => {
+  it('should show version with --version', () => {
+    const program = createProgram();
+    expect(program.version()).toBeDefined();
+    expect(program.version()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('should have wiki command', () => {
+    const program = createProgram();
+    const wiki = program.commands.find(cmd => cmd.name() === 'wiki');
+    expect(wiki).toBeDefined();
+  });
+
+  it('wiki command should have --json option', () => {
+    const program = createProgram();
+    const wiki = program.commands.find(cmd => cmd.name() === 'wiki');
+    expect(wiki).toBeDefined();
+    const jsonOption = wiki!.options.find(opt => opt.long === '--json');
+    expect(jsonOption).toBeDefined();
+  });
+
+  it('wiki command should have all 5 subcommands', () => {
+    const program = createProgram();
+    const wiki = program.commands.find(cmd => cmd.name() === 'wiki');
+    expect(wiki).toBeDefined();
+
+    const expectedCommands = ['init', 'ingest', 'query', 'lint', 'status'];
+    const actualCommands = wiki!.commands.map(cmd => cmd.name());
+
+    for (const expected of expectedCommands) {
+      expect(actualCommands).toContain(expected);
+    }
+  });
+
+  it('plaid wiki --help should list all subcommands', () => {
+    const program = createProgram();
+    const wiki = program.commands.find(cmd => cmd.name() === 'wiki');
+    expect(wiki).toBeDefined();
+
+    const helpText = wiki!.helpInformation();
+    expect(helpText).toContain('init');
+    expect(helpText).toContain('ingest');
+    expect(helpText).toContain('query');
+    expect(helpText).toContain('lint');
+    expect(helpText).toContain('status');
+    expect(helpText).toContain('--json');
+  });
+
+  it('plaid --help should show wiki command', () => {
+    const program = createProgram();
+    const helpText = program.helpInformation();
+    expect(helpText).toContain('wiki');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the CLI entry point for the **plaid wiki** command using Commander.js (task 1.2, wave 1).

### Changes
- **src/cli.ts**: Full CLI entry point with \plaid\ program and \wiki\ subcommand group
- **tests/unit/cli.test.ts**: 6 unit tests covering help, version, and command registration
- **package.json**: Added \commander\ dependency, updated bin field to \{ plaid: ./dist/cli.js }\

### Acceptance Criteria
- [x] src/cli.ts exists with Commander.js program setup
- [x] package.json bin field is \{ plaid: ./dist/cli.js }\
- [x] Running \plaid wiki --help\ shows all 5 commands and --json flag
- [x] Running \plaid --version\ shows package version
- [x] Global --json flag is parsed and available to wiki subcommands
- [x] Each subcommand (init, ingest, query, lint, status) registered under plaid wiki
- [x] Tests exist verifying CLI help output includes all commands
- [x] npm run build produces dist/cli.js that is executable

Closes #6