### PR TITLE
feat(2.2): index file library

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,187 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export interface IndexEntry {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  tags: string[];
+}
+
+export interface FindOptions {
+  title?: string;
+  tags?: string[];
+}
+
+/**
+ * Parse a markdown index entry line into its components.
+ * Format: `- [Title](path) — Summary text #tag1 #tag2`
+ */
+function parseEntryLine(line: string, category: string): IndexEntry | null {
+  const trimmed = line.trim();
+  const entryMatch = trimmed.match(/^-\s+\[([^\]]+)\]\(([^)]+)\)(.*)$/);
+  if (!entryMatch) {
+    return null;
+  }
+
+  const title = entryMatch[1];
+  const path = entryMatch[2];
+  const rest = entryMatch[3].trim();
+
+  let summaryText = '';
+  const tags: string[] = [];
+
+  if (rest) {
+    // Strip leading em-dash, en-dash, or hyphen separator
+    const dashMatch = rest.match(/^[—–-]\s*(.*)$/);
+    const afterDash = dashMatch ? dashMatch[1] : rest;
+
+    // Extract hashtags
+    const tagRegex = /#([\w-]+)/g;
+    let tagMatch: RegExpExecArray | null;
+    while ((tagMatch = tagRegex.exec(afterDash)) !== null) {
+      tags.push(tagMatch[1]);
+    }
+
+    // Summary is everything except tags, trimmed
+    summaryText = afterDash.replace(/#[\w-]+/g, '').trim();
+  }
+
+  return { path, title, summary: summaryText, category, tags };
+}
+
+/**
+ * Format a single index entry as a markdown list item.
+ */
+function formatEntryLine(entry: IndexEntry): string {
+  let line = `- [${entry.title}](${entry.path})`;
+  const parts: string[] = [];
+  if (entry.summary) {
+    parts.push(entry.summary);
+  }
+  if (entry.tags.length > 0) {
+    parts.push(entry.tags.map((t) => `#${t}`).join(' '));
+  }
+  if (parts.length > 0) {
+    line += ` — ${parts.join(' ')}`;
+  }
+  return line;
+}
+
+/**
+ * Parse a categorized markdown index file into an array of IndexEntry objects.
+ * Returns an empty array for missing or empty files.
+ */
+export async function readIndex(filePath: string): Promise<IndexEntry[]> {
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const entries: IndexEntry[] = [];
+  let currentCategory = '';
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+
+    // Detect H2 category heading
+    const categoryMatch = trimmed.match(/^##\s+(.+)$/);
+    if (categoryMatch) {
+      currentCategory = categoryMatch[1].trim();
+      continue;
+    }
+
+    // Only parse entries when inside a category
+    if (currentCategory) {
+      const entry = parseEntryLine(trimmed, currentCategory);
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Serialize an array of IndexEntry objects back to a categorized markdown file.
+ * Entries are grouped by category in the order they first appear.
+ */
+export async function writeIndex(
+  filePath: string,
+  entries: IndexEntry[],
+): Promise<void> {
+  // Group entries by category, preserving insertion order
+  const categories = new Map<string, IndexEntry[]>();
+  for (const entry of entries) {
+    if (!categories.has(entry.category)) {
+      categories.set(entry.category, []);
+    }
+    categories.get(entry.category)!.push(entry);
+  }
+
+  let output = '# Wiki Index\n';
+
+  for (const [category, categoryEntries] of categories) {
+    output += `\n## ${category}\n\n`;
+    for (const entry of categoryEntries) {
+      output += formatEntryLine(entry) + '\n';
+    }
+  }
+
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, output, 'utf-8');
+}
+
+/**
+ * Add an entry to the index file under the appropriate category.
+ * Creates the category if it does not already exist.
+ */
+export async function addEntry(
+  filePath: string,
+  entry: IndexEntry,
+): Promise<void> {
+  const entries = await readIndex(filePath);
+  entries.push(entry);
+  await writeIndex(filePath, entries);
+}
+
+/**
+ * Remove an entry from the index file by its path.
+ * If the path does not exist, the file is left unchanged.
+ */
+export async function removeEntry(
+  filePath: string,
+  path: string,
+): Promise<void> {
+  const entries = await readIndex(filePath);
+  const filtered = entries.filter((e) => e.path !== path);
+  await writeIndex(filePath, filtered);
+}
+
+/**
+ * Search entries by title substring and/or tags.
+ * Title matching is case-insensitive. Tag matching requires at least
+ * one of the provided tags to be present on the entry.
+ */
+export function findEntries(
+  entries: IndexEntry[],
+  options: FindOptions,
+): IndexEntry[] {
+  return entries.filter((entry) => {
+    if (options.title) {
+      if (!entry.title.toLowerCase().includes(options.title.toLowerCase())) {
+        return false;
+      }
+    }
+    if (options.tags && options.tags.length > 0) {
+      if (!options.tags.some((tag) => entry.tags.includes(tag))) {
+        return false;
+      }
+    }
+    return true;
+  });
+}

--- a/tests/fixtures/index/no-summaries.md
+++ b/tests/fixtures/index/no-summaries.md
@@ -1,0 +1,10 @@
+# Wiki Index
+
+## Entities
+
+- [Alan Turing](entities/alan-turing.md)
+- [Claude Shannon](entities/claude-shannon.md)
+
+## Concepts
+
+- [Neural Networks](concepts/neural-networks.md)

--- a/tests/fixtures/index/single-category.md
+++ b/tests/fixtures/index/single-category.md
@@ -1,0 +1,5 @@
+# Wiki Index
+
+## Entities
+
+- [Alan Turing](entities/alan-turing.md) — Father of computer science #computer-science

--- a/tests/fixtures/index/tags-only.md
+++ b/tests/fixtures/index/tags-only.md
@@ -1,0 +1,6 @@
+# Wiki Index
+
+## Concepts
+
+- [Neural Networks](concepts/neural-networks.md) — #ai #deep-learning
+- [Turing Machine](concepts/turing-machine.md) — #computer-science #theory

--- a/tests/fixtures/index/valid-index.md
+++ b/tests/fixtures/index/valid-index.md
@@ -1,0 +1,15 @@
+# Wiki Index
+
+## Entities
+
+- [Alan Turing](entities/alan-turing.md) — Father of computer science #computer-science #mathematics
+- [Claude Shannon](entities/claude-shannon.md) — Information theory pioneer #information-theory #mathematics
+
+## Concepts
+
+- [Neural Networks](concepts/neural-networks.md) — Computational models inspired by biology #ai #deep-learning
+- [Turing Machine](concepts/turing-machine.md) — Abstract model of computation #computer-science
+
+## Sources
+
+- [Turing Biography](sources/turing-bio-summary.md) — Summary of Hodges biography #biography

--- a/tests/lib/index.test.ts
+++ b/tests/lib/index.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  readIndex,
+  writeIndex,
+  addEntry,
+  removeEntry,
+  findEntries,
+} from '../../src/lib/index.js';
+import type { IndexEntry } from '../../src/lib/index.js';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, '..', 'fixtures', 'index');
+
+describe('readIndex', () => {
+  it('should parse a full index with multiple categories', async () => {
+    const entries = await readIndex(join(fixturesDir, 'valid-index.md'));
+    expect(entries).toHaveLength(5);
+
+    const turing = entries.find((e) => e.title === 'Alan Turing');
+    expect(turing).toBeDefined();
+    expect(turing!.path).toBe('entities/alan-turing.md');
+    expect(turing!.summary).toBe('Father of computer science');
+    expect(turing!.category).toBe('Entities');
+    expect(turing!.tags).toEqual(['computer-science', 'mathematics']);
+
+    const nn = entries.find((e) => e.title === 'Neural Networks');
+    expect(nn).toBeDefined();
+    expect(nn!.category).toBe('Concepts');
+    expect(nn!.tags).toEqual(['ai', 'deep-learning']);
+
+    const src = entries.find((e) => e.title === 'Turing Biography');
+    expect(src).toBeDefined();
+    expect(src!.category).toBe('Sources');
+    expect(src!.tags).toEqual(['biography']);
+  });
+
+  it('should return an empty array for an empty file', async () => {
+    const entries = await readIndex(join(fixturesDir, 'empty-index.md'));
+    expect(entries).toEqual([]);
+  });
+
+  it('should return an empty array for a non-existent file', async () => {
+    const entries = await readIndex(join(fixturesDir, 'does-not-exist.md'));
+    expect(entries).toEqual([]);
+  });
+
+  it('should parse entries without summaries or tags', async () => {
+    const entries = await readIndex(join(fixturesDir, 'no-summaries.md'));
+    expect(entries).toHaveLength(3);
+
+    for (const entry of entries) {
+      expect(entry.summary).toBe('');
+      expect(entry.tags).toEqual([]);
+    }
+
+    expect(entries[0].title).toBe('Alan Turing');
+    expect(entries[0].path).toBe('entities/alan-turing.md');
+    expect(entries[0].category).toBe('Entities');
+  });
+
+  it('should parse entries with tags but no summary text', async () => {
+    const entries = await readIndex(join(fixturesDir, 'tags-only.md'));
+    expect(entries).toHaveLength(2);
+
+    expect(entries[0].summary).toBe('');
+    expect(entries[0].tags).toEqual(['ai', 'deep-learning']);
+    expect(entries[1].tags).toEqual(['computer-science', 'theory']);
+  });
+
+  it('should parse a single-category index', async () => {
+    const entries = await readIndex(join(fixturesDir, 'single-category.md'));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].category).toBe('Entities');
+    expect(entries[0].title).toBe('Alan Turing');
+  });
+});
+
+describe('writeIndex', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'index-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should write entries and read them back identically', async () => {
+    const entries: IndexEntry[] = [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: 'Father of CS',
+        category: 'Entities',
+        tags: ['cs', 'math'],
+      },
+      {
+        path: 'concepts/ai.md',
+        title: 'AI',
+        summary: 'Artificial Intelligence',
+        category: 'Concepts',
+        tags: ['ai'],
+      },
+    ];
+
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, entries);
+
+    const readBack = await readIndex(filePath);
+    expect(readBack).toHaveLength(2);
+    expect(readBack[0].title).toBe('Alan Turing');
+    expect(readBack[0].summary).toBe('Father of CS');
+    expect(readBack[0].category).toBe('Entities');
+    expect(readBack[0].tags).toEqual(['cs', 'math']);
+    expect(readBack[1].title).toBe('AI');
+    expect(readBack[1].category).toBe('Concepts');
+  });
+
+  it('should produce valid markdown with # Wiki Index heading', async () => {
+    const entries: IndexEntry[] = [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: '',
+        category: 'Entities',
+        tags: [],
+      },
+    ];
+
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, entries);
+
+    const content = await readFile(filePath, 'utf-8');
+    expect(content).toContain('# Wiki Index');
+    expect(content).toContain('## Entities');
+    expect(content).toContain('- [Alan Turing](entities/turing.md)');
+  });
+
+  it('should write entries without summary or tags cleanly', async () => {
+    const entries: IndexEntry[] = [
+      {
+        path: 'concepts/ai.md',
+        title: 'AI',
+        summary: '',
+        category: 'Concepts',
+        tags: [],
+      },
+    ];
+
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, entries);
+
+    const content = await readFile(filePath, 'utf-8');
+    expect(content).toContain('- [AI](concepts/ai.md)');
+    // Should NOT have a dangling em-dash
+    expect(content).not.toContain('—');
+  });
+
+  it('should group entries by category', async () => {
+    const entries: IndexEntry[] = [
+      { path: 'a.md', title: 'A', summary: '', category: 'Alpha', tags: [] },
+      { path: 'b.md', title: 'B', summary: '', category: 'Beta', tags: [] },
+      { path: 'c.md', title: 'C', summary: '', category: 'Alpha', tags: [] },
+    ];
+
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, entries);
+
+    const readBack = await readIndex(filePath);
+    const alphaEntries = readBack.filter((e) => e.category === 'Alpha');
+    expect(alphaEntries).toHaveLength(2);
+    expect(alphaEntries[0].title).toBe('A');
+    expect(alphaEntries[1].title).toBe('C');
+  });
+
+  it('should create parent directories if needed', async () => {
+    const filePath = join(tmpDir, 'sub', 'dir', 'index.md');
+    await writeIndex(filePath, [
+      { path: 'a.md', title: 'A', summary: '', category: 'Cat', tags: [] },
+    ]);
+
+    const content = await readFile(filePath, 'utf-8');
+    expect(content).toContain('- [A](a.md)');
+  });
+
+  it('should write an empty index when given no entries', async () => {
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, []);
+
+    const content = await readFile(filePath, 'utf-8');
+    expect(content).toContain('# Wiki Index');
+    expect(content).not.toContain('##');
+  });
+});
+
+describe('addEntry', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'index-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should add an entry to an existing category', async () => {
+    const filePath = join(tmpDir, 'index.md');
+    const initial: IndexEntry[] = [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: 'CS pioneer',
+        category: 'Entities',
+        tags: ['cs'],
+      },
+    ];
+    await writeIndex(filePath, initial);
+
+    await addEntry(filePath, {
+      path: 'entities/shannon.md',
+      title: 'Claude Shannon',
+      summary: 'Info theory',
+      category: 'Entities',
+      tags: ['info'],
+    });
+
+    const entries = await readIndex(filePath);
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.category === 'Entities')).toBe(true);
+    expect(entries[1].title).toBe('Claude Shannon');
+  });
+
+  it('should create a new category if it does not exist', async () => {
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: '',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    await addEntry(filePath, {
+      path: 'concepts/ai.md',
+      title: 'AI',
+      summary: 'Artificial Intelligence',
+      category: 'Concepts',
+      tags: ['ai'],
+    });
+
+    const entries = await readIndex(filePath);
+    expect(entries).toHaveLength(2);
+    const categories = [...new Set(entries.map((e) => e.category))];
+    expect(categories).toContain('Entities');
+    expect(categories).toContain('Concepts');
+  });
+
+  it('should add an entry to an empty/missing file', async () => {
+    const filePath = join(tmpDir, 'new-index.md');
+
+    await addEntry(filePath, {
+      path: 'entities/turing.md',
+      title: 'Alan Turing',
+      summary: 'Pioneer',
+      category: 'Entities',
+      tags: ['cs'],
+    });
+
+    const entries = await readIndex(filePath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].title).toBe('Alan Turing');
+  });
+});
+
+describe('removeEntry', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'index-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should remove an entry by path', async () => {
+    const filePath = join(tmpDir, 'index.md');
+    const initial: IndexEntry[] = [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: '',
+        category: 'Entities',
+        tags: [],
+      },
+      {
+        path: 'entities/shannon.md',
+        title: 'Claude Shannon',
+        summary: '',
+        category: 'Entities',
+        tags: [],
+      },
+    ];
+    await writeIndex(filePath, initial);
+
+    await removeEntry(filePath, 'entities/turing.md');
+
+    const entries = await readIndex(filePath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].title).toBe('Claude Shannon');
+  });
+
+  it('should leave file unchanged if path does not exist', async () => {
+    const filePath = join(tmpDir, 'index.md');
+    const initial: IndexEntry[] = [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: '',
+        category: 'Entities',
+        tags: [],
+      },
+    ];
+    await writeIndex(filePath, initial);
+
+    await removeEntry(filePath, 'entities/nonexistent.md');
+
+    const entries = await readIndex(filePath);
+    expect(entries).toHaveLength(1);
+  });
+
+  it('should remove the last entry and leave an empty category-free index', async () => {
+    const filePath = join(tmpDir, 'index.md');
+    await writeIndex(filePath, [
+      {
+        path: 'entities/turing.md',
+        title: 'Alan Turing',
+        summary: '',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    await removeEntry(filePath, 'entities/turing.md');
+
+    const entries = await readIndex(filePath);
+    expect(entries).toEqual([]);
+  });
+});
+
+describe('findEntries', () => {
+  const testEntries: IndexEntry[] = [
+    {
+      path: 'entities/alan-turing.md',
+      title: 'Alan Turing',
+      summary: 'Father of CS',
+      category: 'Entities',
+      tags: ['computer-science', 'mathematics'],
+    },
+    {
+      path: 'entities/claude-shannon.md',
+      title: 'Claude Shannon',
+      summary: 'Info theory',
+      category: 'Entities',
+      tags: ['information-theory', 'mathematics'],
+    },
+    {
+      path: 'concepts/neural-networks.md',
+      title: 'Neural Networks',
+      summary: 'Bio-inspired models',
+      category: 'Concepts',
+      tags: ['ai', 'deep-learning'],
+    },
+    {
+      path: 'concepts/turing-machine.md',
+      title: 'Turing Machine',
+      summary: 'Computation model',
+      category: 'Concepts',
+      tags: ['computer-science'],
+    },
+  ];
+
+  it('should find entries by title substring (case-insensitive)', () => {
+    const results = findEntries(testEntries, { title: 'turing' });
+    expect(results).toHaveLength(2);
+    expect(results.map((e) => e.title)).toContain('Alan Turing');
+    expect(results.map((e) => e.title)).toContain('Turing Machine');
+  });
+
+  it('should find entries by a single tag', () => {
+    const results = findEntries(testEntries, { tags: ['mathematics'] });
+    expect(results).toHaveLength(2);
+    expect(results.map((e) => e.title)).toContain('Alan Turing');
+    expect(results.map((e) => e.title)).toContain('Claude Shannon');
+  });
+
+  it('should find entries matching any of the provided tags', () => {
+    const results = findEntries(testEntries, {
+      tags: ['ai', 'information-theory'],
+    });
+    expect(results).toHaveLength(2);
+    expect(results.map((e) => e.title)).toContain('Claude Shannon');
+    expect(results.map((e) => e.title)).toContain('Neural Networks');
+  });
+
+  it('should filter by both title and tags', () => {
+    const results = findEntries(testEntries, {
+      title: 'turing',
+      tags: ['computer-science'],
+    });
+    expect(results).toHaveLength(2);
+    expect(results.map((e) => e.title)).toContain('Alan Turing');
+    expect(results.map((e) => e.title)).toContain('Turing Machine');
+  });
+
+  it('should return all entries when no filters are provided', () => {
+    const results = findEntries(testEntries, {});
+    expect(results).toHaveLength(4);
+  });
+
+  it('should return empty array when no entries match', () => {
+    const results = findEntries(testEntries, { title: 'nonexistent' });
+    expect(results).toEqual([]);
+  });
+
+  it('should return empty array when tags do not match', () => {
+    const results = findEntries(testEntries, { tags: ['biology'] });
+    expect(results).toEqual([]);
+  });
+
+  it('should return empty array for empty input', () => {
+    const results = findEntries([], { title: 'anything' });
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Task 2.2: Index file library

Implements \src/lib/index.ts\ for managing \wiki/index.md\.

### Functions
- **readIndex** — parse categorized markdown lists into IndexEntry array
- **writeIndex** — serialize IndexEntry array back to categorized markdown
- **addEntry** — insert into correct category, creating category if needed
- **removeEntry** — remove entry by path
- **findEntries** — search by title substring and tags

### Type
- **IndexEntry** — { path, title, summary, category, tags }

### Tests
26 unit tests covering all functions with fixture data. All 45 tests pass (26 new + 19 existing).

### Acceptance Criteria
- [x] src/lib/index.ts exports readIndex, writeIndex, addEntry, removeEntry, findEntries
- [x] IndexEntry type defined with path, title, summary, category, tags fields
- [x] readIndex parses a categorized markdown list into IndexEntry array
- [x] writeIndex serializes IndexEntry array back to categorized markdown
- [x] addEntry inserts into correct category, creating category if needed
- [x] removeEntry removes by path
- [x] findEntries searches by title substring and tags
- [x] Unit tests cover all functions
- [x] All tests pass

Closes task 2.2 from cycle-1 plan.