### PR TITLE
feat(3.1): init command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { registerInitCommand } from './commands/init.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -23,7 +24,11 @@ export function createProgram(): Command {
     .description('Personal knowledge base powered by LLM')
     .option('--json', 'Output results as JSON', false);
 
-  const subcommands = ['init', 'ingest', 'query', 'lint', 'status'] as const;
+  // Register implemented commands
+  registerInitCommand(wiki);
+
+  // Placeholder subcommands for commands not yet implemented
+  const subcommands = ['ingest', 'query', 'lint', 'status'] as const;
 
   for (const name of subcommands) {
     wiki

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,147 @@
+import { Command } from 'commander';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { appendEntry } from '../lib/log.js';
+
+/**
+ * Result of running the init command.
+ */
+export interface InitResult {
+  command: string;
+  status: 'created' | 'already_initialized';
+  created_dirs: string[];
+  created_files: string[];
+  warning?: string;
+}
+
+/** Directories created by init, relative to root. */
+const DIRS = [
+  'raw',
+  'wiki',
+  'wiki/entities',
+  'wiki/concepts',
+  'wiki/sources',
+] as const;
+
+/** The starter wiki/index.md with empty category sections. */
+const INDEX_CONTENT = `# Wiki Index
+
+## Entities
+
+## Concepts
+
+## Sources
+`;
+
+/** AGENTS.md starter schema template. */
+const AGENTS_CONTENT = `# AGENTS.md
+
+## Wiki Schema
+
+### Page Types
+
+- **entity** — A person, place, organization, or thing
+- **concept** — An idea, theory, or abstract topic
+- **source** — A reference to raw material
+
+### Directory Structure
+
+- \`raw/\` — Raw ingested documents
+- \`wiki/\` — Processed wiki pages
+  - \`wiki/entities/\` — Entity pages
+  - \`wiki/concepts/\` — Concept pages
+  - \`wiki/sources/\` — Source reference pages
+  - \`wiki/index.md\` — Master index
+  - \`wiki/log.md\` — Change log
+
+### Frontmatter Schema
+
+\`\`\`yaml
+type: entity | concept | source
+title: string
+tags: string[]
+sources: string[]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+\`\`\`
+`;
+
+/**
+ * Initialize a wiki knowledge base at the given path.
+ * Creates the directory structure, index, log, and AGENTS.md.
+ * Returns a structured result describing what was created.
+ */
+export async function initWiki(targetPath: string): Promise<InitResult> {
+  const root = resolve(targetPath);
+  const wikiDir = join(root, 'wiki');
+
+  // Detect if already initialized
+  try {
+    const wikiStat = await stat(wikiDir);
+    if (wikiStat.isDirectory()) {
+      return {
+        command: 'init',
+        status: 'already_initialized',
+        created_dirs: [],
+        created_files: [],
+        warning: 'Wiki is already initialized (wiki/ directory exists)',
+      };
+    }
+  } catch {
+    // Directory does not exist — proceed with init
+  }
+
+  // Create directory structure
+  for (const dir of DIRS) {
+    await mkdir(join(root, dir), { recursive: true });
+  }
+
+  // Create wiki/index.md with category sections
+  const indexPath = join(root, 'wiki', 'index.md');
+  await writeFile(indexPath, INDEX_CONTENT, 'utf-8');
+
+  // Create wiki/log.md with initialization entry
+  const logPath = join(root, 'wiki', 'log.md');
+  await appendEntry(logPath, {
+    verb: 'initialized',
+    subject: 'wiki',
+    details: 'Wiki knowledge base initialized.',
+  });
+
+  // Create AGENTS.md with starter schema
+  const agentsPath = join(root, 'AGENTS.md');
+  await writeFile(agentsPath, AGENTS_CONTENT, 'utf-8');
+
+  const createdFiles = ['wiki/index.md', 'wiki/log.md', 'AGENTS.md'];
+
+  return {
+    command: 'init',
+    status: 'created',
+    created_dirs: [...DIRS],
+    created_files: createdFiles,
+  };
+}
+
+/**
+ * Register the `init` subcommand on the wiki command group.
+ */
+export function registerInitCommand(wiki: Command): void {
+  wiki
+    .command('init')
+    .description('Initialize a new wiki knowledge base')
+    .option('--path <dir>', 'Target directory', '.')
+    .action(async (options: { path: string }, cmd: Command) => {
+      const jsonMode = cmd.parent?.opts().json ?? false;
+      const result = await initWiki(options.path);
+
+      if (jsonMode) {
+        console.log(JSON.stringify(result));
+      } else if (result.status === 'already_initialized') {
+        console.log(`⚠ ${result.warning}`);
+      } else {
+        console.log('✓ Wiki initialized successfully');
+        console.log(`  Directories: ${result.created_dirs.join(', ')}`);
+        console.log(`  Files: ${result.created_files.join(', ')}`);
+      }
+    });
+}

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initWiki } from '../../src/commands/init.js';
+import { readLog } from '../../src/lib/log.js';
+import { readIndex } from '../../src/lib/index.js';
+import { mkdtemp, rm, readFile, stat, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createProgram } from '../../src/cli.js';
+
+describe('initWiki', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'init-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should create all required directories', async () => {
+    await initWiki(tmpDir);
+
+    const expectedDirs = [
+      'raw',
+      'wiki',
+      'wiki/entities',
+      'wiki/concepts',
+      'wiki/sources',
+    ];
+
+    for (const dir of expectedDirs) {
+      const dirStat = await stat(join(tmpDir, dir));
+      expect(dirStat.isDirectory(), `${dir} should be a directory`).toBe(true);
+    }
+  });
+
+  it('should create wiki/index.md with category headers', async () => {
+    await initWiki(tmpDir);
+
+    const indexContent = await readFile(
+      join(tmpDir, 'wiki', 'index.md'),
+      'utf-8',
+    );
+
+    expect(indexContent).toContain('# Wiki Index');
+    expect(indexContent).toContain('## Entities');
+    expect(indexContent).toContain('## Concepts');
+    expect(indexContent).toContain('## Sources');
+  });
+
+  it('should create wiki/index.md parseable by readIndex', async () => {
+    await initWiki(tmpDir);
+
+    const entries = await readIndex(join(tmpDir, 'wiki', 'index.md'));
+    // Index should be empty but valid (no entries, just category headers)
+    expect(entries).toEqual([]);
+  });
+
+  it('should create wiki/log.md with initialization entry', async () => {
+    await initWiki(tmpDir);
+
+    const logEntries = await readLog(join(tmpDir, 'wiki', 'log.md'));
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0].verb).toBe('initialized');
+    expect(logEntries[0].subject).toBe('wiki');
+    expect(logEntries[0].details).toContain('initialized');
+    expect(logEntries[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('should create AGENTS.md with starter schema', async () => {
+    await initWiki(tmpDir);
+
+    const agentsContent = await readFile(
+      join(tmpDir, 'AGENTS.md'),
+      'utf-8',
+    );
+
+    expect(agentsContent).toContain('# AGENTS.md');
+    expect(agentsContent).toContain('entity');
+    expect(agentsContent).toContain('concept');
+    expect(agentsContent).toContain('source');
+    expect(agentsContent).toContain('Frontmatter Schema');
+  });
+
+  it('should return created status with dirs and files', async () => {
+    const result = await initWiki(tmpDir);
+
+    expect(result.command).toBe('init');
+    expect(result.status).toBe('created');
+    expect(result.created_dirs).toContain('raw');
+    expect(result.created_dirs).toContain('wiki');
+    expect(result.created_dirs).toContain('wiki/entities');
+    expect(result.created_dirs).toContain('wiki/concepts');
+    expect(result.created_dirs).toContain('wiki/sources');
+    expect(result.created_files).toContain('wiki/index.md');
+    expect(result.created_files).toContain('wiki/log.md');
+    expect(result.created_files).toContain('AGENTS.md');
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('should warn if already initialized', async () => {
+    // First init
+    await initWiki(tmpDir);
+
+    // Second init
+    const result = await initWiki(tmpDir);
+
+    expect(result.status).toBe('already_initialized');
+    expect(result.created_dirs).toEqual([]);
+    expect(result.created_files).toEqual([]);
+    expect(result.warning).toContain('already initialized');
+  });
+
+  it('should work with a nested target path', async () => {
+    const nestedPath = join(tmpDir, 'sub', 'project');
+
+    const result = await initWiki(nestedPath);
+
+    expect(result.status).toBe('created');
+
+    const dirStat = await stat(join(nestedPath, 'wiki', 'entities'));
+    expect(dirStat.isDirectory()).toBe(true);
+
+    const indexContent = await readFile(
+      join(nestedPath, 'wiki', 'index.md'),
+      'utf-8',
+    );
+    expect(indexContent).toContain('# Wiki Index');
+  });
+});
+
+describe('init CLI integration', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'init-cli-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should register init command with --path option', () => {
+    const program = createProgram();
+    const wiki = program.commands.find((cmd) => cmd.name() === 'wiki');
+    expect(wiki).toBeDefined();
+
+    const init = wiki!.commands.find((cmd) => cmd.name() === 'init');
+    expect(init).toBeDefined();
+    expect(init!.description()).toBe(
+      'Initialize a new wiki knowledge base',
+    );
+
+    const pathOption = init!.options.find((opt) => opt.long === '--path');
+    expect(pathOption).toBeDefined();
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        '--json',
+        'init',
+        '--path',
+        tmpDir,
+      ]);
+
+      expect(logs).toHaveLength(1);
+      const result = JSON.parse(logs[0]);
+      expect(result.command).toBe('init');
+      expect(result.status).toBe('created');
+      expect(result.created_dirs).toContain('wiki');
+      expect(result.created_files).toContain('wiki/index.md');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should output JSON with warning when already initialized', async () => {
+    // Pre-create wiki dir to trigger "already initialized"
+    await mkdir(join(tmpDir, 'wiki'), { recursive: true });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        '--json',
+        'init',
+        '--path',
+        tmpDir,
+      ]);
+
+      expect(logs).toHaveLength(1);
+      const result = JSON.parse(logs[0]);
+      expect(result.status).toBe('already_initialized');
+      expect(result.warning).toContain('already initialized');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should output human-friendly text by default', async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        'init',
+        '--path',
+        tmpDir,
+      ]);
+
+      const output = logs.join('\n');
+      expect(output).toContain('Wiki initialized successfully');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should output warning text when already initialized', async () => {
+    await mkdir(join(tmpDir, 'wiki'), { recursive: true });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        'init',
+        '--path',
+        tmpDir,
+      ]);
+
+      const output = logs.join('\n');
+      expect(output).toContain('already initialized');
+    } finally {
+      console.log = origLog;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Implements the \plaid wiki init\ command — creates wiki directory structure and starter files.

## Changes
- **src/commands/init.ts**: \initWiki()\ function + \egisterInitCommand()\ CLI wiring
- **src/cli.ts**: Wired init command, removed from placeholder loop
- **tests/commands/init.test.ts**: 13 integration tests

## What Init Creates
- Directories: \aw/\, \wiki/\, \wiki/entities/\, \wiki/concepts/\, \wiki/sources/\`n- \wiki/index.md\ — with Entities, Concepts, Sources category headers
- \wiki/log.md\ — with initialization entry
- \AGENTS.md\ — starter schema template

## Features
- \--path <dir>\ flag for target directory
- \--json\ output: \{command, status, created_files, created_dirs}\`n- Warns if already initialized (wiki/ exists)

## Tests
- 72/72 passing (13 new + 59 existing)

Task: 3.1 | Plan: cycle-1 | Wave: 3