### PR TITLE
feat(4.1): lint command with wiki health checks

### DIFF
--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -1,3 +1,4 @@
+- [2026-04-09T20:57:00Z] [commander] cycle=cycle-1 action=execute-task task=4.1 summary=Completed task 4.1 (Lint command): src/commands/lint.ts with 5 check categories (broken-links, orphan-pages, index-completeness, stale-entries, missing-pages), --category filter, --json output, 17 tests. All 103 tests pass. Opened PR #14.
 - [2026-04-09T20:38:00Z] [commander] cycle=cycle-1 action=merge-pr summary=Reviewed and merged PR #13 (feat(3.2): status command) via squash merge. Task 3.2 complete. Wave 3 finished. Ready for wave 4 (tasks 4.1, 4.2).
 - [2026-04-09T20:33:00Z] [commander] cycle=cycle-1 action=merge-pr summary=Reviewed and merged PR #12 (feat(3.1): init command) via squash merge. Task 3.1 complete. Executing task 3.2 (Status command).
 - [2026-04-09T20:29:00Z] [commander] cycle=cycle-1 action=execute-task task=3.1 summary=Completed task 3.1 (Init command): src/commands/init.ts with directory scaffolding, AGENTS.md template, --path and --json support, 13 integration tests. All 72 tests pass. Opened PR #12.
@@ -38,3 +39,6 @@
 - [2026-04-09T20:09:35.006Z] [commander] cycle=18 action=review-pr summary=Reviewed PR #10 (feat(2.2): index file library): LGTM — clean implementation, 26/26 tests pass, CI green, no Copilot review pending. Ready to merge.
 - [2026-04-09T13:11:43Z] [commander] cycle=cycle-1 action=merge-pr summary=Merged PR #10 (feat(2.2): index file library) via squash merge. Task 2.2 complete. Now executing task 2.3 (Log file library).
 - [2026-04-09T20:17:02.894Z] [commander] cycle=19 action=execute-task summary=Merged PR #10 (task 2.2), delegated task 2.3 (Log file library) to gem-orchestrator on branch task/cycle-1/2.3
+- [2026-04-09T20:48:45.543Z] [commander] cycle=20 action=unknown summary=Could not parse commander output
+- [2026-04-09T20:51:55.264Z] [commander] cycle=21 action=unknown summary=Could not parse commander output
+- [2026-04-09T20:55:18.267Z] [commander] cycle=22 action=unknown summary=Could not parse commander output

--- a/docs/state.json
+++ b/docs/state.json
@@ -12,7 +12,7 @@
     "2.3": { "status": "completed", "attempts": 1, "pr": 11, "merged": true },
     "3.1": { "status": "completed", "attempts": 1, "pr": 12, "merged": true },
     "3.2": { "status": "completed", "attempts": 1, "pr": 13, "merged": true },
-    "4.1": { "status": "pending", "attempts": 0 },
+    "4.1": { "status": "completed", "attempts": 1, "pr": 14 },
     "4.2": { "status": "pending", "attempts": 0 },
     "5.1": { "status": "pending", "attempts": 0 },
     "5.2": { "status": "pending", "attempts": 0 },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { registerInitCommand } from './commands/init.js';
+import { registerLintCommand } from './commands/lint.js';
 import { registerStatusCommand } from './commands/status.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -27,10 +28,11 @@ export function createProgram(): Command {
 
   // Register implemented commands
   registerInitCommand(wiki);
+  registerLintCommand(wiki);
   registerStatusCommand(wiki);
 
   // Placeholder subcommands for commands not yet implemented
-  const subcommands = ['ingest', 'query', 'lint'] as const;
+  const subcommands = ['ingest', 'query'] as const;
 
   for (const name of subcommands) {
     wiki

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,0 +1,251 @@
+import { Command } from 'commander';
+import { access, constants } from 'node:fs/promises';
+import { join, resolve, relative, dirname } from 'node:path';
+import { listPages, readPage, getPageLinks } from '../lib/wiki.js';
+import { readIndex } from '../lib/index.js';
+
+export interface LintFinding {
+  severity: 'error' | 'warning' | 'info';
+  category: string;
+  message: string;
+  file?: string;
+}
+
+export interface LintResult {
+  command: string;
+  findings: LintFinding[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a path to use forward slashes for consistent comparison.
+ */
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/**
+ * Run lint checks on a wiki knowledge base.
+ * If categories is provided and non-empty, only run those check categories.
+ */
+export async function lintWiki(
+  targetPath: string,
+  categories?: string[],
+): Promise<LintResult> {
+  const root = resolve(targetPath);
+  const wikiDir = join(root, 'wiki');
+  const indexPath = join(wikiDir, 'index.md');
+
+  const findings: LintFinding[] = [];
+
+  const shouldRun = (cat: string): boolean =>
+    !categories || categories.length === 0 || categories.includes(cat);
+
+  // Gather wiki pages (excluding index.md and log.md)
+  const allPages = await listPages(wikiDir);
+  const wikiPages = allPages.filter((p) => {
+    const rel = normalizePath(relative(wikiDir, p));
+    return rel !== 'index.md' && rel !== 'log.md';
+  });
+
+  // Build a set of existing wiki page relative paths
+  const existingPagePaths = new Set(
+    wikiPages.map((p) => normalizePath(relative(wikiDir, p))),
+  );
+
+  // Read all pages and collect links
+  const pageContents = new Map<string, string>(); // fullPath → body
+  const pageLinks = new Map<string, string[]>(); // fullPath → link targets (resolved relative paths)
+  const inboundLinks = new Set<string>(); // relative paths that are linked TO
+
+  for (const pagePath of wikiPages) {
+    try {
+      const page = await readPage(pagePath);
+      pageContents.set(pagePath, page.body);
+      const links = getPageLinks(page.body);
+      const resolvedLinks: string[] = [];
+      for (const link of links) {
+        const resolved = resolve(dirname(pagePath), link);
+        const rel = normalizePath(relative(wikiDir, resolved));
+        resolvedLinks.push(rel);
+        inboundLinks.add(rel);
+      }
+      pageLinks.set(pagePath, resolvedLinks);
+    } catch {
+      // Could not read page — skip
+    }
+  }
+
+  // Read index
+  const indexEntries = await readIndex(indexPath);
+  const indexedPaths = new Set(indexEntries.map((e) => normalizePath(e.path)));
+
+  // ── broken-links: Links pointing to non-existent files ──
+  if (shouldRun('broken-links')) {
+    for (const [pagePath, links] of pageLinks) {
+      const pageRel = normalizePath(relative(wikiDir, pagePath));
+      for (const linkRel of links) {
+        if (!existingPagePaths.has(linkRel)) {
+          findings.push({
+            severity: 'error',
+            category: 'broken-links',
+            message: `Broken link to "${linkRel}" in page "${pageRel}"`,
+            file: pageRel,
+          });
+        }
+      }
+    }
+  }
+
+  // ── orphan-pages: No inbound links AND not in index ──
+  if (shouldRun('orphan-pages')) {
+    for (const pageRel of existingPagePaths) {
+      if (!inboundLinks.has(pageRel) && !indexedPaths.has(pageRel)) {
+        findings.push({
+          severity: 'warning',
+          category: 'orphan-pages',
+          message: `Orphan page "${pageRel}" — not linked and not indexed`,
+          file: pageRel,
+        });
+      }
+    }
+  }
+
+  // ── index-completeness: Every wiki page should be in index ──
+  if (shouldRun('index-completeness')) {
+    for (const pageRel of existingPagePaths) {
+      if (!indexedPaths.has(pageRel)) {
+        findings.push({
+          severity: 'warning',
+          category: 'index-completeness',
+          message: `Page "${pageRel}" is not listed in index.md`,
+          file: pageRel,
+        });
+      }
+    }
+  }
+
+  // ── stale-entries: Index entries pointing to deleted files ──
+  if (shouldRun('stale-entries')) {
+    for (const entry of indexEntries) {
+      const entryPath = normalizePath(entry.path);
+      const fullPath = join(wikiDir, entryPath);
+      if (!(await fileExists(fullPath))) {
+        findings.push({
+          severity: 'error',
+          category: 'stale-entries',
+          message: `Stale index entry "${entry.title}" points to missing file "${entryPath}"`,
+          file: entryPath,
+        });
+      }
+    }
+  }
+
+  // ── missing-pages: Unique missing link targets (deduped info) ──
+  if (shouldRun('missing-pages')) {
+    const missingSet = new Set<string>();
+    for (const [, links] of pageLinks) {
+      for (const linkRel of links) {
+        if (!existingPagePaths.has(linkRel) && !missingSet.has(linkRel)) {
+          missingSet.add(linkRel);
+          findings.push({
+            severity: 'info',
+            category: 'missing-pages',
+            message: `Referenced page "${linkRel}" does not exist`,
+            file: linkRel,
+          });
+        }
+      }
+    }
+  }
+
+  const errorCount = findings.filter((f) => f.severity === 'error').length;
+  const warningCount = findings.filter((f) => f.severity === 'warning').length;
+  const infoCount = findings.filter((f) => f.severity === 'info').length;
+
+  return {
+    command: 'lint',
+    findings,
+    errorCount,
+    warningCount,
+    infoCount,
+  };
+}
+
+/**
+ * Format lint result as human-readable output.
+ */
+function formatLintOutput(result: LintResult): string {
+  const lines: string[] = [];
+
+  if (result.findings.length === 0) {
+    lines.push('✓ No lint issues found');
+    return lines.join('\n');
+  }
+
+  const severityIcon: Record<string, string> = {
+    error: '✗',
+    warning: '⚠',
+    info: 'ℹ',
+  };
+
+  const errors = result.findings.filter((f) => f.severity === 'error');
+  const warnings = result.findings.filter((f) => f.severity === 'warning');
+  const infos = result.findings.filter((f) => f.severity === 'info');
+
+  for (const group of [errors, warnings, infos]) {
+    for (const finding of group) {
+      const icon = severityIcon[finding.severity];
+      lines.push(`${icon} [${finding.category}] ${finding.message}`);
+    }
+  }
+
+  lines.push('');
+  const parts: string[] = [];
+  if (result.errorCount > 0) parts.push(`${result.errorCount} error(s)`);
+  if (result.warningCount > 0) parts.push(`${result.warningCount} warning(s)`);
+  if (result.infoCount > 0) parts.push(`${result.infoCount} info(s)`);
+  lines.push(`Summary: ${parts.join(', ')}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Register the `lint` subcommand on the wiki command group.
+ */
+export function registerLintCommand(wiki: Command): void {
+  wiki
+    .command('lint')
+    .description('Run health checks on the wiki knowledge base')
+    .option('--path <dir>', 'Target directory', '.')
+    .option('--category <categories>', 'Comma-separated list of check categories to run')
+    .action(async (options: { path: string; category?: string }, cmd: Command) => {
+      const jsonMode = cmd.parent?.opts().json ?? false;
+      const categories = options.category
+        ? options.category.split(',').map((c) => c.trim())
+        : undefined;
+
+      const result = await lintWiki(options.path, categories);
+
+      if (jsonMode) {
+        console.log(JSON.stringify(result));
+      } else {
+        console.log(formatLintOutput(result));
+      }
+
+      if (result.errorCount > 0) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/tests/commands/lint.test.ts
+++ b/tests/commands/lint.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { lintWiki, LintResult, LintFinding } from '../../src/commands/lint.js';
+import { writeIndex } from '../../src/lib/index.js';
+import { writePage } from '../../src/lib/wiki.js';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createProgram } from '../../src/cli.js';
+
+describe('lintWiki', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'lint-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return zero findings for a clean wiki', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    // Create a page that is indexed and has no broken links
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'A person page with no links.',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir);
+
+    expect(result.command).toBe('lint');
+    expect(result.findings).toHaveLength(0);
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+    expect(result.infoCount).toBe(0);
+  });
+
+  it('should detect broken links', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [nonexistent](../concepts/nonexistent.md) for more.',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir);
+
+    const brokenLinks = result.findings.filter(
+      (f) => f.category === 'broken-links',
+    );
+    expect(brokenLinks.length).toBeGreaterThanOrEqual(1);
+    expect(brokenLinks[0].severity).toBe('error');
+    expect(brokenLinks[0].file).toContain('person.md');
+    expect(result.errorCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should detect orphan pages', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+    await mkdir(join(tmpDir, 'wiki', 'concepts'), { recursive: true });
+
+    // person.md is indexed, orphan.md is NOT indexed and NOT linked
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'A person page.',
+    });
+    await writePage(join(tmpDir, 'wiki', 'concepts', 'orphan.md'), {
+      frontmatter: { type: 'concept', title: 'Orphan' },
+      body: 'Nobody links here.',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir);
+
+    const orphans = result.findings.filter(
+      (f) => f.category === 'orphan-pages',
+    );
+    expect(orphans.length).toBe(1);
+    expect(orphans[0].severity).toBe('warning');
+    expect(orphans[0].message).toContain('orphan.md');
+    expect(result.warningCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should not flag a page as orphan if it is linked from another page', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+    await mkdir(join(tmpDir, 'wiki', 'concepts'), { recursive: true });
+
+    // person.md links to idea.md, idea.md is NOT in index but is linked
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [idea](../concepts/idea.md) for more.',
+    });
+    await writePage(join(tmpDir, 'wiki', 'concepts', 'idea.md'), {
+      frontmatter: { type: 'concept', title: 'Idea' },
+      body: 'An idea page.',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir);
+
+    const orphans = result.findings.filter(
+      (f) => f.category === 'orphan-pages',
+    );
+    expect(orphans).toHaveLength(0);
+  });
+
+  it('should detect index-completeness issues', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    // Page exists but is NOT in index
+    await writePage(join(tmpDir, 'wiki', 'entities', 'missing.md'), {
+      frontmatter: { type: 'entity', title: 'Missing' },
+      body: 'Not in index.',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), []);
+
+    const result = await lintWiki(tmpDir);
+
+    const completeness = result.findings.filter(
+      (f) => f.category === 'index-completeness',
+    );
+    expect(completeness.length).toBe(1);
+    expect(completeness[0].severity).toBe('warning');
+    expect(completeness[0].message).toContain('missing.md');
+  });
+
+  it('should detect stale entries', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    // Index references a file that doesn't exist
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/ghost.md',
+        title: 'Ghost',
+        summary: 'Does not exist',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir);
+
+    const stale = result.findings.filter(
+      (f) => f.category === 'stale-entries',
+    );
+    expect(stale.length).toBe(1);
+    expect(stale[0].severity).toBe('error');
+    expect(stale[0].message).toContain('ghost.md');
+    expect(result.errorCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should detect missing-pages as info findings', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [gone](../concepts/gone.md) and [also gone](../concepts/gone.md).',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir);
+
+    const missing = result.findings.filter(
+      (f) => f.category === 'missing-pages',
+    );
+    // missing-pages reports unique missing targets (deduped)
+    expect(missing.length).toBe(1);
+    expect(missing[0].severity).toBe('info');
+    expect(missing[0].message).toContain('gone.md');
+    expect(result.infoCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should filter by category when categories are provided', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    // Create a broken link AND a stale entry — but only ask for broken-links
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [missing](../concepts/missing.md).',
+    });
+
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+      {
+        path: 'entities/ghost.md',
+        title: 'Ghost',
+        summary: 'Stale',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const result = await lintWiki(tmpDir, ['broken-links']);
+
+    // Only broken-links findings should be present
+    const categories = new Set(result.findings.map((f) => f.category));
+    expect(categories.has('stale-entries')).toBe(false);
+    expect(categories.has('broken-links')).toBe(true);
+  });
+
+  it('should handle empty/uninitialized wiki gracefully', async () => {
+    // tmpDir has no wiki/ directory at all
+    const result = await lintWiki(tmpDir);
+
+    expect(result.command).toBe('lint');
+    expect(result.findings).toHaveLength(0);
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+    expect(result.infoCount).toBe(0);
+  });
+
+  it('should handle wiki with only index.md and log.md', async () => {
+    await mkdir(join(tmpDir, 'wiki'), { recursive: true });
+    await writeFile(join(tmpDir, 'wiki', 'index.md'), '# Wiki Index\n');
+    await writeFile(join(tmpDir, 'wiki', 'log.md'), '');
+
+    const result = await lintWiki(tmpDir);
+
+    expect(result.command).toBe('lint');
+    expect(result.findings).toHaveLength(0);
+  });
+});
+
+describe('lint CLI integration', () => {
+  let tmpDir: string;
+  let origExitCode: number | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'lint-cli-test-'));
+    origExitCode = process.exitCode;
+  });
+
+  afterEach(async () => {
+    process.exitCode = origExitCode;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should register lint command with --path and --category options', () => {
+    const program = createProgram();
+    const wiki = program.commands.find((cmd) => cmd.name() === 'wiki');
+    expect(wiki).toBeDefined();
+
+    const lint = wiki!.commands.find((cmd) => cmd.name() === 'lint');
+    expect(lint).toBeDefined();
+
+    const pathOption = lint!.options.find((opt) => opt.long === '--path');
+    expect(pathOption).toBeDefined();
+
+    const categoryOption = lint!.options.find(
+      (opt) => opt.long === '--category',
+    );
+    expect(categoryOption).toBeDefined();
+  });
+
+  it('should output JSON when --json flag is set', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'A person.',
+    });
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        '--json',
+        'lint',
+        '--path',
+        tmpDir,
+      ]);
+
+      expect(logs).toHaveLength(1);
+      const result = JSON.parse(logs[0]) as LintResult;
+      expect(result.command).toBe('lint');
+      expect(result.findings).toBeDefined();
+      expect(typeof result.errorCount).toBe('number');
+      expect(typeof result.warningCount).toBe('number');
+      expect(typeof result.infoCount).toBe('number');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should output human-readable text with severity symbols', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    // Create a broken link to generate an error finding
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [missing](../concepts/missing.md).',
+    });
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        'lint',
+        '--path',
+        tmpDir,
+      ]);
+
+      const output = logs.join('\n');
+      // Should contain error symbol
+      expect(output).toContain('✗');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should set process.exitCode = 1 when errors exist', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [missing](../concepts/missing.md).',
+    });
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        'lint',
+        '--path',
+        tmpDir,
+      ]);
+
+      expect(process.exitCode).toBe(1);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should not set process.exitCode = 1 when no errors exist', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'A clean page.',
+    });
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        'lint',
+        '--path',
+        tmpDir,
+      ]);
+
+      expect(process.exitCode).not.toBe(1);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should support --category filter via CLI', async () => {
+    await mkdir(join(tmpDir, 'wiki', 'entities'), { recursive: true });
+
+    // Broken link + stale entry, filter only broken-links
+    await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
+      frontmatter: { type: 'entity', title: 'Person' },
+      body: 'See [missing](../concepts/missing.md).',
+    });
+    await writeIndex(join(tmpDir, 'wiki', 'index.md'), [
+      {
+        path: 'entities/person.md',
+        title: 'Person',
+        summary: 'A person',
+        category: 'Entities',
+        tags: [],
+      },
+      {
+        path: 'entities/ghost.md',
+        title: 'Ghost',
+        summary: 'Stale',
+        category: 'Entities',
+        tags: [],
+      },
+    ]);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        '--json',
+        'lint',
+        '--path',
+        tmpDir,
+        '--category',
+        'broken-links',
+      ]);
+
+      const result = JSON.parse(logs[0]) as LintResult;
+      const categories = new Set(result.findings.map((f: LintFinding) => f.category));
+      expect(categories.has('stale-entries')).toBe(false);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should output summary line in human-readable mode', async () => {
+    await mkdir(join(tmpDir, 'wiki'), { recursive: true });
+    await writeFile(join(tmpDir, 'wiki', 'index.md'), '# Wiki Index\n');
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program = createProgram();
+      await program.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        'lint',
+        '--path',
+        tmpDir,
+      ]);
+
+      const output = logs.join('\n');
+      // Clean wiki shows no-issues message
+      expect(output).toContain('No lint issues found');
+    } finally {
+      console.log = origLog;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the \plaid wiki lint\ command (task 4.1) — runs health checks on the wiki knowledge base.

### Lint Check Categories

| Category | Severity | Description |
|----------|----------|-------------|
| \roken-links\ | error | Links pointing to non-existent wiki pages |
| \orphan-pages\ | warning | Pages with no inbound links and not in index |
| \index-completeness\ | warning | Wiki pages not listed in index.md |
| \stale-entries\ | error | Index entries referencing missing files |
| \missing-pages\ | info | Unique missing link targets (deduped) |

### Features
- \--category <categories>\ flag to filter specific check types (comma-separated)
- \--json\ output for agent interop
- Human-readable output with severity symbols (✗/⚠/ℹ)
- Exit code 1 when errors found (\process.exitCode\, not \process.exit()\)

### Tests
- 17 new tests covering all check categories, CLI integration, category filtering, edge cases
- All 103 tests pass (17 new + 86 existing)

### Files Changed
- \src/commands/lint.ts\ — new lint command implementation
- \src/cli.ts\ — register lint command, remove from placeholders
- \	ests/commands/lint.test.ts\ — comprehensive test suite

### Acceptance Criteria
- [x] src/commands/lint.ts implements the lint command
- [x] Checks for broken internal links between wiki pages
- [x] Identifies orphan pages with no inbound links
- [x] Checks index completeness
- [x] Finds stale index entries pointing to deleted files
- [x] Each finding has severity and description
- [x] --category flag filters to specific check types
- [x] --json outputs structured findings array
- [x] Exit code 1 if any errors found, 0 otherwise
- [x] Tests use broken wiki fixtures to verify each check type
- [x] All tests pass