### PR TITLE
feat(5.2): GitHub Actions auto-ingest workflow

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,0 +1,68 @@
+name: Auto-Ingest
+
+on:
+  push:
+    paths:
+      - "raw/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build
+
+      - name: Detect changed files in raw/
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FILES=$(find raw/ -type f 2>/dev/null || true)
+          else
+            FILES=$(git diff --name-only --diff-filter=ACMR HEAD~1 HEAD -- 'raw/' || true)
+          fi
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FILES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILES" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "count=$(echo "$FILES" | wc -l)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ingest changed files
+        if: steps.changed.outputs.count != '0'
+        run: |
+          echo "${{ steps.changed.outputs.files }}" | while IFS= read -r file; do
+            if [ -n "$file" ] && [ -f "$file" ]; then
+              echo "Ingesting: $file"
+              node dist/cli.js wiki ingest "$file"
+            fi
+          done
+
+      - name: Commit wiki updates
+        if: steps.changed.outputs.count != '0'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(wiki): auto-ingest updated sources"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          file_pattern: "wiki/**"

--- a/tests/unit/ingest-workflow.test.ts
+++ b/tests/unit/ingest-workflow.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+// js-yaml is a transitive dependency via gray-matter
+import yaml from 'js-yaml';
+
+const WORKFLOW_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'ingest.yml',
+);
+
+describe('ingest workflow YAML', () => {
+  let content: string;
+  let workflow: Record<string, unknown>;
+
+  // Load and parse once
+  it('should be valid YAML', async () => {
+    content = await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow = yaml.load(content) as Record<string, unknown>;
+    expect(workflow).toBeDefined();
+    expect(typeof workflow).toBe('object');
+  });
+
+  it('should have a name', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+    expect(workflow.name).toBe('Auto-Ingest');
+  });
+
+  it('should trigger on push to raw/** paths', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const on = workflow.on as Record<string, unknown>;
+    expect(on).toBeDefined();
+
+    const push = on.push as Record<string, unknown>;
+    expect(push).toBeDefined();
+    expect(push.paths).toEqual(expect.arrayContaining(['raw/**']));
+  });
+
+  it('should support workflow_dispatch', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const on = workflow.on as Record<string, unknown>;
+    expect(on).toHaveProperty('workflow_dispatch');
+  });
+
+  it('should set up Node.js 20', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const nodeStep = steps.find(
+      (s) => s.uses && (s.uses as string).startsWith('actions/setup-node'),
+    );
+    expect(nodeStep).toBeDefined();
+    expect((nodeStep!.with as Record<string, unknown>)['node-version']).toBe(20);
+  });
+
+  it('should run npm ci', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const npmCiStep = steps.find((s) => s.run && (s.run as string).includes('npm ci'));
+    expect(npmCiStep).toBeDefined();
+  });
+
+  it('should build the CLI', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const buildStep = steps.find((s) => s.run && (s.run as string).includes('npm run build'));
+    expect(buildStep).toBeDefined();
+  });
+
+  it('should detect changed files using git diff', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const diffStep = steps.find(
+      (s) => s.run && (s.run as string).includes('git diff'),
+    );
+    expect(diffStep).toBeDefined();
+    expect((diffStep!.run as string)).toContain('raw/');
+  });
+
+  it('should run ingest for each changed file', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const ingestStep = steps.find(
+      (s) => s.run && (s.run as string).includes('dist/cli.js wiki ingest'),
+    );
+    expect(ingestStep).toBeDefined();
+  });
+
+  it('should use stefanzweifel/git-auto-commit-action@v5', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const commitStep = steps.find(
+      (s) => s.uses && (s.uses as string).includes('stefanzweifel/git-auto-commit-action@v5'),
+    );
+    expect(commitStep).toBeDefined();
+  });
+
+  it('should use bot user identity for commits', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const commitStep = steps.find(
+      (s) => s.uses && (s.uses as string).includes('git-auto-commit-action'),
+    );
+    expect(commitStep).toBeDefined();
+    const withConfig = commitStep!.with as Record<string, unknown>;
+    expect(withConfig.commit_user_name).toContain('github-actions[bot]');
+    expect(withConfig.commit_user_email).toContain('github-actions[bot]');
+  });
+
+  it('should use GITHUB_TOKEN (not PAT) — permissions.contents set', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const permissions = workflow.permissions as Record<string, unknown>;
+    expect(permissions).toBeDefined();
+    expect(permissions.contents).toBe('write');
+
+    // Ensure no PAT reference
+    expect(content).not.toContain('PAT');
+    expect(content).not.toContain('PERSONAL_ACCESS_TOKEN');
+  });
+
+  it('should checkout with fetch-depth 0 for full git diff history', async () => {
+    content ??= await readFile(WORKFLOW_PATH, 'utf-8');
+    workflow ??= yaml.load(content) as Record<string, unknown>;
+
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const ingest = jobs.ingest as Record<string, unknown>;
+    const steps = ingest.steps as Array<Record<string, unknown>>;
+
+    const checkoutStep = steps.find(
+      (s) => s.uses && (s.uses as string).startsWith('actions/checkout'),
+    );
+    expect(checkoutStep).toBeDefined();
+    expect((checkoutStep!.with as Record<string, unknown>)['fetch-depth']).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements task 5.2: GitHub Actions ingest workflow that automatically processes source files pushed to \aw/\.

## Changes

- **\.github/workflows/ingest.yml\** — Auto-ingest workflow
  - Triggers on push to \aw/**\ paths and \workflow_dispatch\
  - Sets up Node.js 20, installs deps, builds CLI
  - Detects changed files in \aw/\ via \git diff\
  - Runs \
ode dist/cli.js wiki ingest\ for each changed file
  - Commits wiki updates using \stefanzweifel/git-auto-commit-action@v5\
  - Uses bot identity (\github-actions[bot]\) and GITHUB_TOKEN (prevents infinite loops)

- **\	ests/unit/ingest-workflow.test.ts\** — 13 YAML validation tests
  - Validates workflow structure, triggers, Node.js setup, build steps
  - Verifies ingest command usage, auto-commit config, permissions

## Acceptance Criteria

- [x] \.github/workflows/ingest.yml\ exists and is valid YAML
- [x] Triggers on push to \aw/**\ paths
- [x] Supports \workflow_dispatch\ for manual runs
- [x] Sets up Node.js and runs \
pm ci\
- [x] Detects changed files in \aw/\ using \git diff\
- [x] Runs ingest for each changed file
- [x] Commits wiki updates with bot user identity
- [x] Uses GITHUB_TOKEN, not a PAT
- [x] Uses \stefanzweifel/git-auto-commit-action@v5\
- [x] Does not trigger infinite loops

## Test Results

All 158 tests pass (145 existing + 13 new workflow validation tests).