### PR TITLE
docs(6.2): AGENTS.md starter schema template

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -43,6 +43,7 @@ const AGENTS_CONTENT = `# AGENTS.md
 - **entity** — A person, place, organization, or thing
 - **concept** — An idea, theory, or abstract topic
 - **source** — A reference to raw material
+- **summary** — An auto-generated summary of an ingested source
 
 ### Directory Structure
 
@@ -56,14 +57,65 @@ const AGENTS_CONTENT = `# AGENTS.md
 
 ### Frontmatter Schema
 
+**Required fields:**
+- \`type\` — Page type (entity, concept, source, summary)
+- \`title\` — Page title
+
+**Optional fields:**
+- \`tags\` — Array of tag strings
+- \`sources\` — Array of source references
+- \`created\` — Creation date (YYYY-MM-DD)
+- \`updated\` — Last updated date (YYYY-MM-DD)
+- \`source_path\` — Relative path to the original source file
+- \`ingested\` — Date the source was ingested
+
 \`\`\`yaml
-type: entity | concept | source
+type: entity | concept | source | summary
 title: string
 tags: string[]
 sources: string[]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
+source_path: string   # source/summary pages only
+ingested: YYYY-MM-DD  # source/summary pages only
 \`\`\`
+
+### Naming Conventions
+
+- Filenames are lowercased
+- Extensions are stripped
+- Non-alphanumeric characters become hyphens
+- Leading/trailing hyphens are removed
+- Example: \`My Report (2024).pdf\` → \`my-report-2024\`
+- Summary pages: \`sources/{slug}-summary.md\`
+- Entity pages: \`entities/{slug}.md\`
+- Concept pages: \`concepts/{slug}.md\`
+
+### Ingest Workflow
+
+1. Place raw file in \`raw/\` directory
+2. Run \`plaid wiki ingest <source>\` (supports \`--dry-run\`)
+3. A summary page is created in \`wiki/sources/\`
+4. \`wiki/index.md\` is updated with the new entry
+5. \`wiki/log.md\` records the ingestion event
+
+### Lint Rules
+
+- **broken-links** (error) — Links pointing to non-existent files
+- **orphan-pages** (warning) — Pages with no inbound links and not in index
+- **index-completeness** (warning) — Pages not listed in wiki/index.md
+- **stale-entries** (error) — Index entries pointing to deleted files
+- **missing-pages** (info) — Referenced pages that do not exist yet
+
+Run lint: \`plaid wiki lint\` (supports \`--category\` filter)
+
+### Cross-Referencing Guidelines
+
+- Use standard Markdown links: \`[Title](relative/path.md)\`
+- Links must be relative paths ending in \`.md\`
+- External URLs (http/https) are ignored by lint
+- Use relative paths from the current file location
+- The lint command detects broken links and orphan pages
 `;
 
 /**

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -81,6 +81,13 @@ describe('initWiki', () => {
     expect(agentsContent).toContain('concept');
     expect(agentsContent).toContain('source');
     expect(agentsContent).toContain('Frontmatter Schema');
+    expect(agentsContent).toContain('summary');
+    expect(agentsContent).toContain('Naming Conventions');
+    expect(agentsContent).toContain('Ingest Workflow');
+    expect(agentsContent).toContain('Lint Rules');
+    expect(agentsContent).toContain('Cross-Referencing');
+    expect(agentsContent).toContain('broken-links');
+    expect(agentsContent).toContain('orphan-pages');
   });
 
   it('should return created status with dirs and files', async () => {


### PR DESCRIPTION
## Summary

Expands the AGENTS.md starter schema template created by \plaid wiki init\ to include comprehensive documentation of wiki conventions.

## Changes

- **src/commands/init.ts**: Expanded \AGENTS_CONTENT\ from ~30 to ~80 lines with 7 sections:
  - Page types (entity, concept, source, summary)
  - Directory structure
  - Frontmatter schema (required vs optional fields)
  - Naming conventions
  - Ingest workflow (5-step user guide)
  - Lint rules (all 5 checks with severity)
  - Cross-referencing guidelines

- **tests/commands/init.test.ts**: 7 new assertions verifying all sections present in generated AGENTS.md

## Testing

All 193 tests pass (including 35 E2E tests).

## Task

Completes task 6.2 from cycle-1 plan. This is the final task in the cycle.