### PR TITLE
feat(c2-02): add listSources and getBacklinks APIs to shared package

### DIFF
--- a/packages/shared/src/backlinks.ts
+++ b/packages/shared/src/backlinks.ts
@@ -1,0 +1,70 @@
+import { basename, dirname, join, relative } from 'node:path';
+import { listPages, readPage, getPageLinks } from './wiki.js';
+
+export interface BacklinkResult {
+  /** Absolute path of the page containing the backlink */
+  sourcePage: string;
+  /** Title from the source page's frontmatter (or filename if missing) */
+  sourceTitle: string;
+  /** The link text used in the markdown link */
+  linkText: string;
+}
+
+/**
+ * Find all wiki pages that contain links pointing to `targetPage`.
+ *
+ * `targetPage` should be a relative path (e.g. "concepts/ai.md") as it
+ * appears in markdown link targets.
+ *
+ * Iterates all pages via `listPages()`, extracts links with `getPageLinks()`,
+ * and resolves each link relative to the source page's directory to compare
+ * against the target.
+ */
+export async function getBacklinks(
+  wikiDir: string,
+  targetPage: string,
+): Promise<BacklinkResult[]> {
+  const pages = await listPages(wikiDir);
+  const results: BacklinkResult[] = [];
+
+  // Normalise target to forward-slash relative path
+  const normTarget = targetPage.replace(/\\/g, '/');
+
+  for (const pagePath of pages) {
+    const page = await readPage(pagePath);
+    const links = getPageLinks(page.body);
+
+    // The link regex returns (linkText, linkTarget) — we need the text too
+    // Re-extract with text since getPageLinks only returns targets
+    const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+    let match: RegExpExecArray | null;
+    while ((match = linkRegex.exec(page.body)) !== null) {
+      const linkText = match[1];
+      const linkTarget = match[2];
+
+      // Skip external and non-.md links (same filter as getPageLinks)
+      if (
+        !linkTarget.endsWith('.md') ||
+        linkTarget.startsWith('http://') ||
+        linkTarget.startsWith('https://')
+      ) {
+        continue;
+      }
+
+      // Resolve the link relative to the source page's directory
+      const sourceDir = dirname(pagePath);
+      const resolvedAbsolute = join(sourceDir, linkTarget);
+      const resolvedRelative = relative(wikiDir, resolvedAbsolute).replace(/\\/g, '/');
+
+      if (resolvedRelative === normTarget) {
+        results.push({
+          sourcePage: pagePath,
+          sourceTitle: page.frontmatter.title ?? basename(pagePath, '.md'),
+          linkText,
+        });
+      }
+    }
+  }
+
+  return results;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
 export * from './wiki.js';
 export * from './index-ops.js';
 export * from './log.js';
+export * from './sources.js';
+export * from './backlinks.js';

--- a/packages/shared/src/sources.ts
+++ b/packages/shared/src/sources.ts
@@ -1,0 +1,50 @@
+import { readdir, stat } from 'node:fs/promises';
+import { join, extname, basename } from 'node:path';
+
+export interface SourceFile {
+  /** File name including extension */
+  name: string;
+  /** Relative path from rawDir */
+  path: string;
+  /** File size in bytes */
+  size: number;
+  /** Last modified date as ISO string */
+  modified: string;
+  /** File extension including the dot (e.g. ".txt") */
+  extension: string;
+}
+
+/**
+ * List all files in a raw sources directory with metadata.
+ * Returns an empty array if the directory does not exist.
+ */
+export async function listSources(rawDir: string): Promise<SourceFile[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(rawDir, { recursive: true }) as unknown as string[];
+  } catch {
+    return [];
+  }
+
+  const results: SourceFile[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(rawDir, entry);
+    try {
+      const s = await stat(fullPath);
+      if (s.isFile()) {
+        results.push({
+          name: basename(entry),
+          path: entry.replace(/\\/g, '/'),
+          size: s.size,
+          modified: s.mtime.toISOString(),
+          extension: extname(entry),
+        });
+      }
+    } catch {
+      // Skip entries that can't be stat'd (e.g. broken symlinks)
+    }
+  }
+
+  return results;
+}

--- a/tests/shared/backlinks.test.ts
+++ b/tests/shared/backlinks.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getBacklinks } from '../../packages/shared/src/backlinks.js';
+import { writePage } from '../../packages/shared/src/wiki.js';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('getBacklinks', () => {
+  let tmpDir: string;
+  let wikiDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'backlinks-test-'));
+    wikiDir = join(tmpDir, 'wiki');
+    await mkdir(wikiDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return empty array when no pages exist', async () => {
+    const result = await getBacklinks(wikiDir, 'target.md');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when wiki directory does not exist', async () => {
+    const result = await getBacklinks(join(tmpDir, 'nonexistent'), 'target.md');
+    expect(result).toEqual([]);
+  });
+
+  it('should find backlinks from pages linking to the target', async () => {
+    // Create target page
+    await writePage(join(wikiDir, 'concepts', 'ai.md'), {
+      frontmatter: { title: 'Artificial Intelligence' },
+      body: 'AI is the simulation of human intelligence.',
+    });
+
+    // Create a page that links to the target
+    await writePage(join(wikiDir, 'entities', 'turing.md'), {
+      frontmatter: { title: 'Alan Turing' },
+      body: 'Turing pioneered [artificial intelligence](../concepts/ai.md) and computation.',
+    });
+
+    // Create a page that does NOT link to the target
+    await writePage(join(wikiDir, 'entities', 'shannon.md'), {
+      frontmatter: { title: 'Claude Shannon' },
+      body: 'Shannon worked on information theory.',
+    });
+
+    const result = await getBacklinks(wikiDir, 'concepts/ai.md');
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceTitle).toBe('Alan Turing');
+    expect(result[0].linkText).toBe('artificial intelligence');
+    expect(result[0].sourcePage).toContain('turing.md');
+  });
+
+  it('should find multiple backlinks from different pages', async () => {
+    await writePage(join(wikiDir, 'target.md'), {
+      frontmatter: { title: 'Target Page' },
+      body: 'I am the target.',
+    });
+
+    await writePage(join(wikiDir, 'page-a.md'), {
+      frontmatter: { title: 'Page A' },
+      body: 'See [the target](target.md) for details.',
+    });
+
+    await writePage(join(wikiDir, 'page-b.md'), {
+      frontmatter: { title: 'Page B' },
+      body: 'Also see [target page](target.md) here.',
+    });
+
+    const result = await getBacklinks(wikiDir, 'target.md');
+    expect(result).toHaveLength(2);
+
+    const titles = result.map((r) => r.sourceTitle).sort();
+    expect(titles).toEqual(['Page A', 'Page B']);
+  });
+
+  it('should find multiple backlinks from the same page', async () => {
+    await writePage(join(wikiDir, 'target.md'), {
+      frontmatter: { title: 'Target' },
+      body: 'Target content.',
+    });
+
+    await writePage(join(wikiDir, 'linker.md'), {
+      frontmatter: { title: 'Linker Page' },
+      body: 'First [link one](target.md) and second [link two](target.md).',
+    });
+
+    const result = await getBacklinks(wikiDir, 'target.md');
+    expect(result).toHaveLength(2);
+    expect(result[0].linkText).toBe('link one');
+    expect(result[1].linkText).toBe('link two');
+  });
+
+  it('should use filename as title when frontmatter title is missing', async () => {
+    await writePage(join(wikiDir, 'target.md'), {
+      frontmatter: { title: 'Target' },
+      body: 'Target content.',
+    });
+
+    await writePage(join(wikiDir, 'no-title.md'), {
+      frontmatter: {},
+      body: 'See [here](target.md).',
+    });
+
+    const result = await getBacklinks(wikiDir, 'target.md');
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceTitle).toBe('no-title');
+  });
+
+  it('should ignore external links', async () => {
+    await writePage(join(wikiDir, 'target.md'), {
+      frontmatter: { title: 'Target' },
+      body: 'Target content.',
+    });
+
+    await writePage(join(wikiDir, 'external.md'), {
+      frontmatter: { title: 'External Links' },
+      body: 'See [Google](https://google.com) and [example](http://example.com/target.md).',
+    });
+
+    const result = await getBacklinks(wikiDir, 'target.md');
+    expect(result).toEqual([]);
+  });
+
+  it('should handle nested directory structure with relative links', async () => {
+    await mkdir(join(wikiDir, 'concepts'), { recursive: true });
+    await mkdir(join(wikiDir, 'entities'), { recursive: true });
+
+    await writePage(join(wikiDir, 'concepts', 'cs.md'), {
+      frontmatter: { title: 'Computer Science' },
+      body: 'CS is a broad field.',
+    });
+
+    // Link from sibling directory using relative path
+    await writePage(join(wikiDir, 'entities', 'turing.md'), {
+      frontmatter: { title: 'Alan Turing' },
+      body: 'Turing contributed to [computer science](../concepts/cs.md).',
+    });
+
+    // Link from same directory
+    await writePage(join(wikiDir, 'concepts', 'algorithms.md'), {
+      frontmatter: { title: 'Algorithms' },
+      body: 'Algorithms are part of [CS](cs.md).',
+    });
+
+    const result = await getBacklinks(wikiDir, 'concepts/cs.md');
+    expect(result).toHaveLength(2);
+
+    const titles = result.map((r) => r.sourceTitle).sort();
+    expect(titles).toEqual(['Alan Turing', 'Algorithms']);
+  });
+});

--- a/tests/shared/sources.test.ts
+++ b/tests/shared/sources.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { listSources } from '../../packages/shared/src/sources.js';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('listSources', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'sources-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return empty array for non-existent directory', async () => {
+    const result = await listSources(join(tmpDir, 'does-not-exist'));
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for empty directory', async () => {
+    const rawDir = join(tmpDir, 'raw');
+    await mkdir(rawDir);
+    const result = await listSources(rawDir);
+    expect(result).toEqual([]);
+  });
+
+  it('should list files with correct metadata', async () => {
+    const rawDir = join(tmpDir, 'raw');
+    await mkdir(rawDir);
+
+    const content = 'Hello, world!';
+    await writeFile(join(rawDir, 'notes.txt'), content, 'utf-8');
+
+    const result = await listSources(rawDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('notes.txt');
+    expect(result[0].path).toBe('notes.txt');
+    expect(result[0].size).toBe(Buffer.byteLength(content));
+    expect(result[0].extension).toBe('.txt');
+    // modified should be a valid ISO date string
+    expect(() => new Date(result[0].modified)).not.toThrow();
+    expect(new Date(result[0].modified).getTime()).toBeGreaterThan(0);
+  });
+
+  it('should list files in nested directories', async () => {
+    const rawDir = join(tmpDir, 'raw');
+    await mkdir(join(rawDir, 'sub', 'deep'), { recursive: true });
+
+    await writeFile(join(rawDir, 'top.txt'), 'top-level', 'utf-8');
+    await writeFile(join(rawDir, 'sub', 'mid.pdf'), 'mid-level', 'utf-8');
+    await writeFile(join(rawDir, 'sub', 'deep', 'bottom.md'), 'deep-level', 'utf-8');
+
+    const result = await listSources(rawDir);
+    expect(result).toHaveLength(3);
+
+    const paths = result.map((f) => f.path).sort();
+    expect(paths).toEqual(['sub/deep/bottom.md', 'sub/mid.pdf', 'top.txt']);
+
+    // Check extensions
+    const byName = Object.fromEntries(result.map((f) => [f.name, f]));
+    expect(byName['top.txt'].extension).toBe('.txt');
+    expect(byName['mid.pdf'].extension).toBe('.pdf');
+    expect(byName['bottom.md'].extension).toBe('.md');
+  });
+
+  it('should not include directories in results', async () => {
+    const rawDir = join(tmpDir, 'raw');
+    await mkdir(join(rawDir, 'subdir'), { recursive: true });
+    await writeFile(join(rawDir, 'file.txt'), 'data', 'utf-8');
+
+    const result = await listSources(rawDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('file.txt');
+  });
+
+  it('should handle multiple files with different extensions', async () => {
+    const rawDir = join(tmpDir, 'raw');
+    await mkdir(rawDir);
+
+    await writeFile(join(rawDir, 'doc.txt'), 'text', 'utf-8');
+    await writeFile(join(rawDir, 'data.json'), '{}', 'utf-8');
+    await writeFile(join(rawDir, 'image.png'), 'fake-png', 'utf-8');
+
+    const result = await listSources(rawDir);
+    expect(result).toHaveLength(3);
+
+    const extensions = result.map((f) => f.extension).sort();
+    expect(extensions).toEqual(['.json', '.png', '.txt']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two new functions to \@llmwiki/shared\ for use by the VS Code extension tree views (wave 4 tasks c2-09, c2-10).

### listSources(rawDir)
- Lists all files in \aw/\ with metadata: name, relative path, size, modified date, extension
- Handles nested subdirectories via recursive \eaddir\
- Returns empty array if directory doesn't exist

### getBacklinks(wikiDir, targetPage)
- Finds all wiki pages that link to a target page
- Resolves relative links to compare against the target
- Returns source page path, title (from frontmatter), and link text

### Testing
- 14 new unit tests covering edge cases (empty dirs, nested files, relative link resolution, multiple backlinks, external link filtering, missing titles)
- All 207 tests pass (193 existing + 14 new)

### Acceptance Criteria
- [x] \listSources(rawDir)\ exported from \@llmwiki/shared\
- [x] \getBacklinks(wikiDir, targetPage)\ exported from \@llmwiki/shared\
- [x] \SourceFile\ interface: \{ name, path, size, modified, extension }\
- [x] \BacklinkResult\ interface: \{ sourcePage, sourceTitle, linkText }\
- [x] Unit tests cover happy path, empty dir, nested files
- [x] All 207 tests pass

Closes task c2-02 from cycle-2 plan.