### PR TITLE
feat(c2-05): update CI workflow for monorepo builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build shared
+        run: npm run build --workspace=packages/shared
 
-      - name: Lint
-        run: npm run lint
+      - name: Build CLI
+        run: npm run build --workspace=packages/cli
+
+      - name: Build VS Code extension
+        run: npm run build --workspace=packages/vscode
+
+      - name: Lint shared
+        run: npm run lint --workspace=packages/shared
+
+      - name: Lint CLI
+        run: npm run lint --workspace=packages/cli
+
+      - name: Lint VS Code extension
+        run: npm run lint --workspace=packages/vscode
 
       - name: Test
         run: npm test
+        # Note: VS Code extension integration tests require VS Code runtime
+        # and will be added as a separate CI job in task c2-12


### PR DESCRIPTION
## Summary
Update CI workflow to build and lint each monorepo package individually for better failure isolation.

## Changes
- Break monolithic build/lint steps into per-package steps (shared -> cli -> vscode)
- Build order respects dependency graph
- Tests run via vitest (covers shared + cli packages)
- Note: VS Code integration tests will be added in c2-12
- ingest.yml already correct (no changes needed)

## Task
c2-05 (wave 2) | Depends on: c2-01 ✅

## Verification
- All 210 tests pass locally
- Build succeeds for all 3 packages