### PR TITLE
feat(c2-10): implement Backlinks TreeDataProvider

### DIFF
--- a/packages/vscode/src/backlinksTree.ts
+++ b/packages/vscode/src/backlinksTree.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode';
+import { join, relative } from 'node:path';
+import { getBacklinks } from '@llmwiki/shared';
+import type { BacklinkResult } from '@llmwiki/shared';
+
+export class BacklinkTreeItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    collapsibleState: vscode.TreeItemCollapsibleState,
+    options?: {
+      backlink?: BacklinkResult;
+      message?: boolean;
+    },
+  ) {
+    super(label, collapsibleState);
+
+    if (options?.backlink) {
+      this.contextValue = 'backlink';
+      this.description = options.backlink.linkText;
+      this.iconPath = new vscode.ThemeIcon('references');
+      this.command = {
+        command: 'vscode.open',
+        title: 'Open Page',
+        arguments: [vscode.Uri.file(options.backlink.sourcePage)],
+      };
+    } else if (options?.message) {
+      this.contextValue = 'message';
+      this.iconPath = new vscode.ThemeIcon('info');
+    }
+  }
+}
+
+export class BacklinksTreeDataProvider
+  implements vscode.TreeDataProvider<BacklinkTreeItem>, vscode.Disposable
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<
+    BacklinkTreeItem | undefined | null | void
+  >();
+
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private readonly wikiDir: string;
+  private readonly _editorListener: vscode.Disposable;
+  private _debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(private readonly workspaceFolder: string) {
+    this.wikiDir = join(workspaceFolder, 'wiki');
+    this._editorListener = vscode.window.onDidChangeActiveTextEditor(() => {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = setTimeout(() => {
+        this.refresh();
+      }, 200);
+    });
+  }
+
+  getTreeItem(element: BacklinkTreeItem): BacklinkTreeItem {
+    return element;
+  }
+
+  async getChildren(): Promise<BacklinkTreeItem[]> {
+    const activeEditor = vscode.window.activeTextEditor;
+
+    if (!activeEditor) {
+      return [
+        new BacklinkTreeItem(
+          'Open a wiki page to see backlinks',
+          vscode.TreeItemCollapsibleState.None,
+          { message: true },
+        ),
+      ];
+    }
+
+    const fsPath = activeEditor.document.uri.fsPath;
+    const normalizedPath = fsPath.replace(/\\/g, '/');
+    const normalizedWikiDir = this.wikiDir.replace(/\\/g, '/');
+
+    if (!normalizedPath.startsWith(normalizedWikiDir + '/')) {
+      return [
+        new BacklinkTreeItem(
+          'Open a wiki page to see backlinks',
+          vscode.TreeItemCollapsibleState.None,
+          { message: true },
+        ),
+      ];
+    }
+
+    const targetPage = relative(this.wikiDir, fsPath).replace(/\\/g, '/');
+    const results = await getBacklinks(this.wikiDir, targetPage);
+
+    if (results.length === 0) {
+      return [
+        new BacklinkTreeItem(
+          'No backlinks found',
+          vscode.TreeItemCollapsibleState.None,
+          { message: true },
+        ),
+      ];
+    }
+
+    return results.map(
+      (backlink) =>
+        new BacklinkTreeItem(
+          backlink.sourceTitle,
+          vscode.TreeItemCollapsibleState.None,
+          { backlink },
+        ),
+    );
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  dispose(): void {
+    this._onDidChangeTreeData.dispose();
+    this._editorListener.dispose();
+    clearTimeout(this._debounceTimer);
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { WikiPagesTreeDataProvider } from './wikiPagesTree';
 import { RawSourcesTreeDataProvider } from './rawSourcesTree';
+import { BacklinksTreeDataProvider } from './backlinksTree';
 import { registerCommands } from './commands';
 import { createStatusBar } from './statusBar';
 
@@ -23,10 +24,13 @@ export function activate(context: vscode.ExtensionContext): void {
   const wikiPagesProvider = new WikiPagesTreeDataProvider(workspaceFolder);
   const treeRegistration = vscode.window.registerTreeDataProvider('wikiPages', wikiPagesProvider);
 
+  const backlinksProvider = new BacklinksTreeDataProvider(workspaceFolder);
+  const backlinksRegistration = vscode.window.registerTreeDataProvider('backlinks', backlinksProvider);
+
   const watcher = vscode.workspace.createFileSystemWatcher('**/wiki/**/*.md');
-  watcher.onDidChange(() => wikiPagesProvider.refresh());
-  watcher.onDidCreate(() => wikiPagesProvider.refresh());
-  watcher.onDidDelete(() => wikiPagesProvider.refresh());
+  watcher.onDidChange(() => { wikiPagesProvider.refresh(); backlinksProvider.refresh(); });
+  watcher.onDidCreate(() => { wikiPagesProvider.refresh(); backlinksProvider.refresh(); });
+  watcher.onDidDelete(() => { wikiPagesProvider.refresh(); backlinksProvider.refresh(); });
 
   const rawSourcesProvider = new RawSourcesTreeDataProvider(workspaceFolder);
   const rawSourcesRegistration = vscode.window.registerTreeDataProvider('rawSources', rawSourcesProvider);
@@ -40,7 +44,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const statusBar = createStatusBar(context, workspaceFolder);
 
-  context.subscriptions.push(treeRegistration, watcher, wikiPagesProvider, rawSourcesRegistration, rawWatcher, rawSourcesProvider, statusBar);
+  context.subscriptions.push(treeRegistration, watcher, wikiPagesProvider, rawSourcesRegistration, rawWatcher, rawSourcesProvider, backlinksRegistration, backlinksProvider, statusBar);
 }
 
 export function deactivate(): void {

--- a/tests/vscode/backlinksTree.test.ts
+++ b/tests/vscode/backlinksTree.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+const { mockOnDidChangeActiveTextEditor } = vi.hoisted(() => ({
+  mockOnDidChangeActiveTextEditor: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+}));
+
+vi.mock('vscode', () => ({
+  TreeItem: class MockTreeItem {
+    label: string;
+    collapsibleState: number;
+    description?: string;
+    contextValue?: string;
+    iconPath?: { id: string };
+    command?: { command: string; title: string; arguments: unknown[] };
+    constructor(label: string, collapsibleState: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  },
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ThemeIcon: class MockThemeIcon {
+    id: string;
+    constructor(id: string) {
+      this.id = id;
+    }
+  },
+  Uri: {
+    file: (path: string) => ({ fsPath: path, scheme: 'file' }),
+  },
+  EventEmitter: class MockEventEmitter {
+    private _listeners: ((data?: unknown) => void)[] = [];
+    event = (listener: (data?: unknown) => void): { dispose: () => void } => {
+      this._listeners.push(listener);
+      return { dispose: () => {} };
+    };
+    fire(data?: unknown): void {
+      for (const listener of this._listeners) {
+        listener(data);
+      }
+    }
+    dispose(): void {
+      this._listeners = [];
+    }
+  },
+  window: {
+    activeTextEditor: undefined as
+      | { document: { uri: { fsPath: string } } }
+      | undefined,
+    onDidChangeActiveTextEditor: mockOnDidChangeActiveTextEditor,
+  },
+}));
+
+vi.mock('@llmwiki/shared', () => ({
+  getBacklinks: vi.fn(),
+}));
+
+import {
+  BacklinksTreeDataProvider,
+  BacklinkTreeItem,
+} from '../../packages/vscode/src/backlinksTree';
+import { getBacklinks } from '@llmwiki/shared';
+import * as vscode from 'vscode';
+import { join } from 'node:path';
+
+const mockGetBacklinks = getBacklinks as Mock;
+
+const WORKSPACE = '/test/workspace';
+const WIKI_DIR = join(WORKSPACE, 'wiki');
+
+describe('BacklinksTreeDataProvider', () => {
+  let provider: BacklinksTreeDataProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as Record<string, unknown>).activeTextEditor = undefined;
+    provider = new BacklinksTreeDataProvider(WORKSPACE);
+  });
+
+  describe('getChildren — no active wiki file', () => {
+    it('should return guidance message when no editor is active', async () => {
+      (vscode.window as Record<string, unknown>).activeTextEditor = undefined;
+
+      const items = await provider.getChildren();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].label).toBe('Open a wiki page to see backlinks');
+      expect(items[0].contextValue).toBe('message');
+      expect((items[0].iconPath as { id: string }).id).toBe('info');
+      expect(items[0].command).toBeUndefined();
+    });
+
+    it('should return guidance message when active file is not in wiki directory', async () => {
+      (vscode.window as Record<string, unknown>).activeTextEditor = {
+        document: { uri: { fsPath: join(WORKSPACE, 'raw', 'notes.txt') } },
+      };
+
+      const items = await provider.getChildren();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].label).toBe('Open a wiki page to see backlinks');
+      expect(items[0].contextValue).toBe('message');
+    });
+  });
+
+  describe('getChildren — active wiki file with no backlinks', () => {
+    it('should return "No backlinks found" when getBacklinks returns empty', async () => {
+      (vscode.window as Record<string, unknown>).activeTextEditor = {
+        document: { uri: { fsPath: join(WIKI_DIR, 'concepts', 'ai.md') } },
+      };
+      mockGetBacklinks.mockResolvedValue([]);
+
+      const items = await provider.getChildren();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].label).toBe('No backlinks found');
+      expect(items[0].contextValue).toBe('message');
+      expect(mockGetBacklinks).toHaveBeenCalledWith(WIKI_DIR, 'concepts/ai.md');
+    });
+  });
+
+  describe('getChildren — active wiki file with backlinks', () => {
+    const mockBacklinks = [
+      {
+        sourcePage: join(WIKI_DIR, 'overview', 'intro.md'),
+        sourceTitle: 'Introduction',
+        linkText: 'Artificial Intelligence',
+      },
+      {
+        sourcePage: join(WIKI_DIR, 'topics', 'ml.md'),
+        sourceTitle: 'Machine Learning',
+        linkText: 'AI concepts',
+      },
+    ];
+
+    beforeEach(() => {
+      (vscode.window as Record<string, unknown>).activeTextEditor = {
+        document: { uri: { fsPath: join(WIKI_DIR, 'concepts', 'ai.md') } },
+      };
+      mockGetBacklinks.mockResolvedValue(mockBacklinks);
+    });
+
+    it('should return correct number of backlink items', async () => {
+      const items = await provider.getChildren();
+
+      expect(items).toHaveLength(2);
+    });
+
+    it('should set label to sourceTitle', async () => {
+      const items = await provider.getChildren();
+
+      expect(items[0].label).toBe('Introduction');
+      expect(items[1].label).toBe('Machine Learning');
+    });
+
+    it('should set description to linkText', async () => {
+      const items = await provider.getChildren();
+
+      expect(items[0].description).toBe('Artificial Intelligence');
+      expect(items[1].description).toBe('AI concepts');
+    });
+
+    it('should set icon to references', async () => {
+      const items = await provider.getChildren();
+
+      expect((items[0].iconPath as { id: string }).id).toBe('references');
+      expect((items[1].iconPath as { id: string }).id).toBe('references');
+    });
+
+    it('should set contextValue to backlink', async () => {
+      const items = await provider.getChildren();
+
+      expect(items[0].contextValue).toBe('backlink');
+      expect(items[1].contextValue).toBe('backlink');
+    });
+
+    it('should set command to open source page', async () => {
+      const items = await provider.getChildren();
+
+      expect(items[0].command).toBeDefined();
+      expect(items[0].command!.command).toBe('vscode.open');
+      expect(items[0].command!.title).toBe('Open Page');
+      expect(
+        (items[0].command!.arguments![0] as { fsPath: string }).fsPath,
+      ).toBe(join(WIKI_DIR, 'overview', 'intro.md'));
+    });
+
+    it('should call getBacklinks with correct wikiDir and relative target path', async () => {
+      await provider.getChildren();
+
+      expect(mockGetBacklinks).toHaveBeenCalledWith(WIKI_DIR, 'concepts/ai.md');
+    });
+  });
+
+  describe('getTreeItem', () => {
+    it('should return the element as-is', async () => {
+      (vscode.window as Record<string, unknown>).activeTextEditor = undefined;
+
+      const items = await provider.getChildren();
+      const item = items[0];
+
+      expect(provider.getTreeItem(item)).toBe(item);
+    });
+  });
+
+  describe('refresh', () => {
+    it('should fire onDidChangeTreeData event', () => {
+      let fired = false;
+      provider.onDidChangeTreeData(() => {
+        fired = true;
+      });
+
+      provider.refresh();
+
+      expect(fired).toBe(true);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should dispose without errors', () => {
+      expect(() => provider.dispose()).not.toThrow();
+    });
+
+    it('should dispose editor listener', () => {
+      const disposeSpy = vi.fn();
+      mockOnDidChangeActiveTextEditor.mockReturnValue({ dispose: disposeSpy });
+
+      const p = new BacklinksTreeDataProvider(WORKSPACE);
+      p.dispose();
+
+      expect(disposeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('editor change listener', () => {
+    it('should subscribe to onDidChangeActiveTextEditor in constructor', () => {
+      expect(mockOnDidChangeActiveTextEditor).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements the Backlinks TreeDataProvider for the VS Code extension (wave 4, task c2-10).

### Changes
- **packages/vscode/src/backlinksTree.ts** — BacklinksTreeDataProvider with active editor tracking, 200ms debounce, wiki page detection, getBacklinks() from @llmwiki/shared
- **packages/vscode/src/extension.ts** — Register backlinks provider on 'backlinks' view
- **tests/vscode/backlinksTree.test.ts** — 15 unit tests covering all acceptance criteria

### Acceptance Criteria
- [x] BacklinksTreeDataProvider registered on 'backlinks' view
- [x] Responds to active editor changes (200ms debounce)
- [x] Correctly identifies wiki pages via path detection
- [x] Shows source title as label, link text as description
- [x] Handles non-wiki files gracefully (guidance message)
- [x] Shows 'No backlinks found' when empty
- [x] Clicking navigates to source page
- [x] 15 unit tests passing

### Testing
All 270 tests pass (17 test files). Extension builds cleanly.