### PR TITLE
feat(c3-02): add duplicate detection to ingest

### DIFF
--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -12,15 +12,18 @@ export function registerIngestCommand(wiki: Command): void {
     .argument('<source>', 'Path to the source file to ingest')
     .option('--path <dir>', 'Target directory', '.')
     .option('--dry-run', 'Preview changes without writing files', false)
-    .action(async (source: string, options: { path: string; dryRun: boolean }, cmd: Command) => {
+    .option('--force', 'Re-ingest even if source was already ingested', false)
+    .action(async (source: string, options: { path: string; dryRun: boolean; force: boolean }, cmd: Command) => {
       const jsonMode = cmd.parent?.opts().json ?? false;
-      const result = await ingestSource(source, options.path, options.dryRun);
+      const result = await ingestSource(source, options.path, options.dryRun, options.force);
 
       if (jsonMode) {
         console.log(JSON.stringify(result));
       } else if (result.status === 'error') {
         console.error(`✗ ${result.error}`);
         process.exitCode = 1;
+      } else if (result.status === 'skipped') {
+        console.log(`⊘ ${result.message}`);
       } else if (result.dry_run) {
         console.log('Dry run — no files written');
         console.log(`  Would create: ${result.pages_created.join(', ')}`);

--- a/packages/shared/src/ingest.ts
+++ b/packages/shared/src/ingest.ts
@@ -1,7 +1,7 @@
 import { readFile, stat, access, constants } from 'node:fs/promises';
 import { join, resolve, basename, extname, relative } from 'node:path';
 import { writePage, directoryExists } from './wiki.js';
-import { addEntry } from './index-ops.js';
+import { addEntry, removeEntry } from './index-ops.js';
 import { appendEntry } from './log.js';
 import { slugify } from './utils.js';
 
@@ -10,11 +10,12 @@ import { slugify } from './utils.js';
  */
 export interface IngestResult {
   command: string;
-  status: 'success' | 'error';
+  status: 'success' | 'error' | 'skipped';
   pages_created: string[];
   pages_updated: string[];
   dry_run: boolean;
   error?: string;
+  message?: string;
 }
 
 /**
@@ -27,6 +28,7 @@ export async function ingestSource(
   sourcePath: string,
   targetPath: string,
   dryRun: boolean,
+  force: boolean = false,
 ): Promise<IngestResult> {
   const root = resolve(targetPath);
   const wikiDir = join(root, 'wiki');
@@ -84,6 +86,26 @@ export async function ingestSource(
   const summaryRelPath = `sources/${slug}-summary.md`;
   const summaryFullPath = join(wikiDir, summaryRelPath);
 
+  // Duplicate detection — check if summary page already exists
+  let summaryExists = false;
+  try {
+    await access(summaryFullPath, constants.F_OK);
+    summaryExists = true;
+  } catch {
+    // ENOENT — summary does not exist yet; proceed normally
+  }
+
+  if (summaryExists && !force) {
+    return {
+      command: 'ingest',
+      status: 'skipped',
+      pages_created: [],
+      pages_updated: [],
+      dry_run: dryRun,
+      message: 'Source already ingested. Use --force to re-ingest.',
+    };
+  }
+
   // Build content excerpt (first ~500 characters)
   const excerpt = sourceContent.length > 500
     ? sourceContent.slice(0, 500) + '…'
@@ -111,7 +133,10 @@ export async function ingestSource(
     });
     pagesCreated.push(summaryRelPath);
 
-    // Update index
+    // Update index (remove existing entry first when force-overwriting to prevent duplicates)
+    if (force && summaryExists) {
+      await removeEntry(indexPath, summaryRelPath);
+    }
     await addEntry(indexPath, {
       path: summaryRelPath,
       title: sourceFilename,

--- a/tests/cli/commands/ingest.test.ts
+++ b/tests/cli/commands/ingest.test.ts
@@ -221,6 +221,63 @@ describe('ingestSource', () => {
     expect(result.status).toBe('success');
     expect(result.pages_created).toContain('sources/valid-source-summary.md');
   });
+
+  it('should return skipped when ingesting same source twice without --force', async () => {
+    const sourceFile = join(tmpDir, 'raw', 'duplicate.md');
+    await writeFile(sourceFile, 'Duplicate detection test.', 'utf-8');
+
+    const first = await ingestSource(sourceFile, tmpDir, false);
+    expect(first.status).toBe('success');
+
+    const second = await ingestSource(sourceFile, tmpDir, false);
+    expect(second.status).toBe('skipped');
+    expect(second.message).toBe('Source already ingested. Use --force to re-ingest.');
+    expect(second.pages_created).toEqual([]);
+    expect(second.pages_updated).toEqual([]);
+  });
+
+  it('should overwrite and return success when force=true on duplicate', async () => {
+    const sourceFile = join(tmpDir, 'raw', 'force-test.md');
+    await writeFile(sourceFile, 'Original content.', 'utf-8');
+
+    const first = await ingestSource(sourceFile, tmpDir, false);
+    expect(first.status).toBe('success');
+
+    // Update source content then force re-ingest
+    await writeFile(sourceFile, 'Updated content for force.', 'utf-8');
+    const second = await ingestSource(sourceFile, tmpDir, false, true);
+    expect(second.status).toBe('success');
+    expect(second.pages_created).toContain('sources/force-test-summary.md');
+
+    // Verify updated content is in the summary
+    const summaryPath = join(tmpDir, 'wiki', 'sources', 'force-test-summary.md');
+    const raw = await readFile(summaryPath, 'utf-8');
+    expect(raw).toContain('Updated content for force.');
+  });
+
+  it('should not create duplicate index entries on force re-ingest', async () => {
+    const sourceFile = join(tmpDir, 'raw', 'no-dup-index.md');
+    await writeFile(sourceFile, 'Index dup test.', 'utf-8');
+
+    await ingestSource(sourceFile, tmpDir, false);
+    await ingestSource(sourceFile, tmpDir, false, true);
+
+    const entries = await readIndex(join(tmpDir, 'wiki', 'index.md'));
+    const matches = entries.filter((e) => e.path === 'sources/no-dup-index-summary.md');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('should still work for clean first-time ingest (regression)', async () => {
+    const sourceFile = join(tmpDir, 'raw', 'fresh.md');
+    await writeFile(sourceFile, 'Brand new content.', 'utf-8');
+
+    const result = await ingestSource(sourceFile, tmpDir, false, false);
+
+    expect(result.status).toBe('success');
+    expect(result.pages_created).toContain('sources/fresh-summary.md');
+    expect(result.pages_updated).toContain('index.md');
+    expect(result.pages_updated).toContain('log.md');
+  });
 });
 
 describe('ingest CLI integration', () => {
@@ -423,5 +480,56 @@ describe('ingest CLI integration', () => {
     } finally {
       console.error = origErr;
     }
+  });
+
+  it('should output skipped status in JSON when source already ingested', async () => {
+    const sourceFile = join(tmpDir, 'raw', 'skip-json.md');
+    await writeFile(sourceFile, 'Skip JSON test.', 'utf-8');
+
+    // First ingest
+    const program1 = createProgram();
+    await program1.parseAsync([
+      'node',
+      'plaid',
+      'wiki',
+      'ingest',
+      sourceFile,
+      '--path',
+      tmpDir,
+    ]);
+
+    // Second ingest with JSON
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      const program2 = createProgram();
+      await program2.parseAsync([
+        'node',
+        'plaid',
+        'wiki',
+        '--json',
+        'ingest',
+        sourceFile,
+        '--path',
+        tmpDir,
+      ]);
+
+      expect(logs).toHaveLength(1);
+      const result = JSON.parse(logs[0]);
+      expect(result.status).toBe('skipped');
+      expect(result.message).toBe('Source already ingested. Use --force to re-ingest.');
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  it('should register --force option on ingest command', () => {
+    const program = createProgram();
+    const wiki = program.commands.find((cmd) => cmd.name() === 'wiki');
+    const ingest = wiki!.commands.find((cmd) => cmd.name() === 'ingest');
+    const forceOption = ingest!.options.find((opt) => opt.long === '--force');
+    expect(forceOption).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds duplicate detection to the ingest command to prevent silent data corruption when re-ingesting sources.

### Changes

- **packages/shared/src/ingest.ts**: Added 'skipped' status to IngestResult, added orce parameter to ingestSource(), duplicate check before creating summary page, index entry dedup on force re-ingest
- **packages/cli/src/commands/ingest.ts**: Added --force flag, handle skipped status in JSON and human output
- **tests/cli/commands/ingest.test.ts**: 6 new tests covering skip, force, index dedup, regression, CLI JSON skip, --force option registration

### Behavior

- Ingesting a source that already has a summary page returns \status: 'skipped'\ with a helpful message
- \--force\ flag overrides the check and re-ingests, cleaning up duplicate index entries
- All 313 tests pass (307 existing + 6 new)

### Task

Implements task c3-02 from cycle-3 plan.