### PR TITLE
feat(c3-03): add frontmatter-validation lint category

### DIFF
--- a/packages/shared/src/ingest.ts
+++ b/packages/shared/src/ingest.ts
@@ -127,6 +127,7 @@ export async function ingestSource(
         title: sourceFilename,
         source_path: relativeSourcePath,
         ingested: today,
+        created: today,
         tags: [],
       },
       body: `# ${sourceFilename}\n\n**Source:** ${relativeSourcePath}  \n**Type:** ${sourceExt || 'unknown'}  \n**Size:** ${sourceStat.size} bytes  \n**Ingested:** ${today}\n\n## Content Preview\n\n${excerpt}`,

--- a/packages/shared/src/lint.ts
+++ b/packages/shared/src/lint.ts
@@ -1,6 +1,6 @@
 import { access, constants } from 'node:fs/promises';
 import { join, resolve, relative, dirname } from 'node:path';
-import { listPages, readPage, getPageLinks } from './wiki.js';
+import { listPages, readPage, getPageLinks, type WikiPageFrontmatter } from './wiki.js';
 import { readIndex } from './index-ops.js';
 
 export interface LintFinding {
@@ -16,6 +16,7 @@ export interface LintResult {
   errorCount: number;
   warningCount: number;
   infoCount: number;
+  categorySummary: Record<string, number>;
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -66,6 +67,7 @@ export async function lintWiki(
 
   // Read all pages and collect links
   const pageContents = new Map<string, string>(); // fullPath → body
+  const pageFrontmatter = new Map<string, WikiPageFrontmatter>(); // fullPath → frontmatter
   const pageLinks = new Map<string, string[]>(); // fullPath → link targets (resolved relative paths)
   const inboundLinks = new Set<string>(); // relative paths that are linked TO
 
@@ -73,6 +75,7 @@ export async function lintWiki(
     try {
       const page = await readPage(pagePath);
       pageContents.set(pagePath, page.body);
+      pageFrontmatter.set(pagePath, page.frontmatter);
       const links = getPageLinks(page.body);
       const resolvedLinks: string[] = [];
       for (const link of links) {
@@ -170,9 +173,67 @@ export async function lintWiki(
     }
   }
 
+  // ── frontmatter-validation: Check page frontmatter fields ──
+  if (shouldRun('frontmatter-validation')) {
+    const validTypes = ['entity', 'concept', 'source', 'summary', 'query'];
+    for (const pagePath of wikiPages) {
+      const pageRel = normalizePath(relative(wikiDir, pagePath));
+      const fm = pageFrontmatter.get(pagePath);
+      if (!fm) continue;
+
+      if (!fm.type) {
+        findings.push({
+          severity: 'error',
+          category: 'frontmatter-validation',
+          message: `Missing required "type" field in frontmatter of "${pageRel}"`,
+          file: pageRel,
+        });
+      } else if (!validTypes.includes(fm.type)) {
+        findings.push({
+          severity: 'warning',
+          category: 'frontmatter-validation',
+          message: `Invalid type "${fm.type}" in "${pageRel}" — expected one of: ${validTypes.join(', ')}`,
+          file: pageRel,
+        });
+      }
+
+      if (!fm.title) {
+        findings.push({
+          severity: 'error',
+          category: 'frontmatter-validation',
+          message: `Missing required "title" field in frontmatter of "${pageRel}"`,
+          file: pageRel,
+        });
+      }
+
+      if (!fm.tags) {
+        findings.push({
+          severity: 'info',
+          category: 'frontmatter-validation',
+          message: `Missing recommended "tags" field in "${pageRel}"`,
+          file: pageRel,
+        });
+      }
+
+      if (!fm.created) {
+        findings.push({
+          severity: 'info',
+          category: 'frontmatter-validation',
+          message: `Missing recommended "created" field in "${pageRel}"`,
+          file: pageRel,
+        });
+      }
+    }
+  }
+
   const errorCount = findings.filter((f) => f.severity === 'error').length;
   const warningCount = findings.filter((f) => f.severity === 'warning').length;
   const infoCount = findings.filter((f) => f.severity === 'info').length;
+
+  const categorySummary: Record<string, number> = {};
+  for (const f of findings) {
+    categorySummary[f.category] = (categorySummary[f.category] ?? 0) + 1;
+  }
 
   return {
     command: 'lint',
@@ -180,5 +241,6 @@ export async function lintWiki(
     errorCount,
     warningCount,
     infoCount,
+    categorySummary,
   };
 }

--- a/tests/cli/commands/lint.test.ts
+++ b/tests/cli/commands/lint.test.ts
@@ -23,7 +23,7 @@ describe('lintWiki', () => {
 
     // Create a page that is indexed and has no broken links
     await writePage(join(tmpDir, 'wiki', 'entities', 'person.md'), {
-      frontmatter: { type: 'entity', title: 'Person' },
+      frontmatter: { type: 'entity', title: 'Person', tags: ['test'], created: '2026-04-10' },
       body: 'A person page with no links.',
     });
 


### PR DESCRIPTION
## Summary

Adds a 6th lint category **frontmatter-validation** to the shared lint module that validates wiki page frontmatter fields:

### Checks
| Rule | Severity | Trigger |
|------|----------|---------|
| Missing \	ype\ field | error | Required field absent |
| Missing \	itle\ field | error | Required field absent |
| Invalid \	ype\ value | warning | Not one of: entity, concept, source, summary, query |
| Missing \	ags\ field | info | Recommended field absent |
| Missing \created\ field | info | Recommended field absent |

### Changes
- **packages/shared/src/lint.ts** — Added frontmatter-validation category with 5 checks
- **packages/shared/src/ingest.ts** — Added \created\ field to ingest-generated summary pages

### Testing
- All 320 tests pass (320 passed, 0 failed)
- Build succeeds for all packages

### Task
Closes task c3-03 from cycle-3 plan.