### PR TITLE
docs(c3-08): add query page type to AGENTS.md template

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -44,6 +44,7 @@ const AGENTS_CONTENT = `# AGENTS.md
 - **concept** — An idea, theory, or abstract topic
 - **source** — A reference to raw material
 - **summary** — An auto-generated summary of an ingested source
+- **query** — A saved query result page, created by \`plaid wiki query --save\`
 
 ### Directory Structure
 
@@ -58,7 +59,7 @@ const AGENTS_CONTENT = `# AGENTS.md
 ### Frontmatter Schema
 
 **Required fields:**
-- \`type\` — Page type (entity, concept, source, summary)
+- \`type\` — Page type (entity, concept, source, summary, query)
 - \`title\` — Page title
 
 **Optional fields:**
@@ -70,14 +71,30 @@ const AGENTS_CONTENT = `# AGENTS.md
 - \`ingested\` — Date the source was ingested
 
 \`\`\`yaml
-type: entity | concept | source | summary
+type: entity | concept | source | summary | query
 title: string
 tags: string[]
 sources: string[]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
-source_path: string   # source/summary pages only
-ingested: YYYY-MM-DD  # source/summary pages only
+source_path: string       # source/summary pages only
+ingested: YYYY-MM-DD      # source/summary pages only
+query: string             # query pages only — the original query string
+results_count: number     # query pages only — number of results
+\`\`\`
+
+### Query Page Frontmatter
+
+Query pages are created by \`plaid wiki query --save\` and use the following frontmatter:
+
+\`\`\`yaml
+type: query
+title: "<the query string>"
+tags:
+  - <derived from query terms>
+created: YYYY-MM-DD
+query: "<the original query string>"
+results_count: <number of results>
 \`\`\`
 
 ### Naming Conventions

--- a/tests/cli/commands/init.test.ts
+++ b/tests/cli/commands/init.test.ts
@@ -82,6 +82,10 @@ describe('initWiki', () => {
     expect(agentsContent).toContain('source');
     expect(agentsContent).toContain('Frontmatter Schema');
     expect(agentsContent).toContain('summary');
+    expect(agentsContent).toContain('query');
+    expect(agentsContent).toContain('Query Page Frontmatter');
+    expect(agentsContent).toContain('plaid wiki query --save');
+    expect(agentsContent).toContain('results_count');
     expect(agentsContent).toContain('Naming Conventions');
     expect(agentsContent).toContain('Ingest Workflow');
     expect(agentsContent).toContain('Lint Rules');


### PR DESCRIPTION
## Summary
Adds the 'query' page type to the AGENTS.md template generated by \plaid wiki init\.

## Changes
- Added 'query' to the page types list (entity, concept, source, summary, **query**)
- Documented query page frontmatter schema: type, title, tags, created, query, results_count
- Noted that query pages are created by \plaid wiki query --save\
- Updated init test assertions to verify new content

## Task
- Plan: cycle-3, Task: c3-08
- Wave 3 (schema documentation)
- All 367 tests passing