### PR TITLE
feat(c4-04): smart write MCP tools — wiki_write_page and wiki_update_page

### DIFF
--- a/packages/shared/src/mcp/index.ts
+++ b/packages/shared/src/mcp/index.ts
@@ -1,1 +1,4 @@
 export { createMcpServer } from './server.js';
+export { READ_TOOLS, handleReadToolCall, assertWithinDir } from './read-tools.js';
+export type { ToolArgs } from './read-tools.js';
+export { WRITE_TOOLS, handleWriteToolCall } from './write-tools.js';

--- a/packages/shared/src/mcp/read-tools.ts
+++ b/packages/shared/src/mcp/read-tools.ts
@@ -1,9 +1,4 @@
 import { join, resolve } from 'node:path';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
 import { getWikiStatus } from '../status.js';
 import { queryWiki } from '../query.js';
 import { lintWiki } from '../lint.js';
@@ -116,10 +111,10 @@ export const READ_TOOLS: ToolDefinition[] = [
 // Tool handler dispatch
 // ---------------------------------------------------------------------------
 
-type ToolArgs = Record<string, unknown>;
+export type ToolArgs = Record<string, unknown>;
 
 /** Validate that a required argument is a non-empty string. */
-function requireString(args: ToolArgs, key: string): string {
+export function requireString(args: ToolArgs, key: string): string {
   const val = args[key];
   if (typeof val !== 'string' || val.length === 0) {
     throw new Error(`'${key}' must be a non-empty string`);
@@ -128,7 +123,7 @@ function requireString(args: ToolArgs, key: string): string {
 }
 
 /** Validate that an optional argument, if present, is a string. */
-function optionalString(args: ToolArgs, key: string): string | undefined {
+export function optionalString(args: ToolArgs, key: string): string | undefined {
   const val = args[key];
   if (val === undefined || val === null) return undefined;
   if (typeof val !== 'string') {
@@ -141,7 +136,7 @@ function optionalString(args: ToolArgs, key: string): string | undefined {
  * S-7: Prevent path traversal — resolved path must stay within baseDir.
  * Mirrors the guard in ingest.ts.
  */
-function assertWithinDir(baseDir: string, relPath: string): string {
+export function assertWithinDir(baseDir: string, relPath: string): string {
   const resolvedBase = resolve(baseDir).replace(/\\/g, '/');
   const resolvedFull = resolve(baseDir, relPath).replace(/\\/g, '/');
   if (!resolvedFull.startsWith(resolvedBase + '/') && resolvedFull !== resolvedBase) {
@@ -151,7 +146,7 @@ function assertWithinDir(baseDir: string, relPath: string): string {
 }
 
 /** Resolve a tool call to its result text. */
-async function handleToolCall(
+export async function handleReadToolCall(
   name: string,
   args: ToolArgs,
   wikiRoot: string,
@@ -209,32 +204,4 @@ async function handleToolCall(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Registration
-// ---------------------------------------------------------------------------
 
-/**
- * Register all read-only tool handlers on the given MCP server instance.
- *
- * @param server  MCP Server instance
- * @param wikiRoot  Absolute (or relative) path to the wiki root directory
- */
-export function registerReadTools(server: Server, wikiRoot: string): void {
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: READ_TOOLS,
-  }));
-
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params;
-    try {
-      const text = await handleToolCall(name, (args ?? {}) as ToolArgs, wikiRoot);
-      return { content: [{ type: 'text' as const, text }] };
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${message}` }],
-        isError: true,
-      };
-    }
-  });
-}

--- a/packages/shared/src/mcp/server.ts
+++ b/packages/shared/src/mcp/server.ts
@@ -1,5 +1,14 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { registerReadTools } from './read-tools.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { READ_TOOLS, handleReadToolCall } from './read-tools.js';
+import type { ToolArgs } from './read-tools.js';
+import { WRITE_TOOLS, handleWriteToolCall } from './write-tools.js';
+
+const READ_TOOL_NAMES = new Set(READ_TOOLS.map((t) => t.name));
+const WRITE_TOOL_NAMES = new Set(WRITE_TOOLS.map((t) => t.name));
 
 /**
  * Create a fully-configured MCP server for LLM Wiki.
@@ -17,7 +26,32 @@ export function createMcpServer(wikiRoot: string): Server {
     { capabilities: { tools: {} } },
   );
 
-  registerReadTools(server, wikiRoot);
+  // Unified tool listing: read + write tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [...READ_TOOLS, ...WRITE_TOOLS],
+  }));
+
+  // Unified call dispatch: route to the correct handler
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    try {
+      let text: string;
+      if (READ_TOOL_NAMES.has(name)) {
+        text = await handleReadToolCall(name, (args ?? {}) as ToolArgs, wikiRoot);
+      } else if (WRITE_TOOL_NAMES.has(name)) {
+        text = await handleWriteToolCall(name, (args ?? {}) as ToolArgs, wikiRoot);
+      } else {
+        throw new Error(`Unknown tool: ${name}`);
+      }
+      return { content: [{ type: 'text' as const, text }] };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
 
   return server;
 }

--- a/packages/shared/src/mcp/write-tools.ts
+++ b/packages/shared/src/mcp/write-tools.ts
@@ -1,0 +1,251 @@
+import { join } from 'node:path';
+import { readPage, writePage } from '../wiki.js';
+import { readIndex, writeIndex } from '../index-ops.js';
+import type { IndexEntry } from '../index-ops.js';
+import { isNotFoundError } from '../errors.js';
+import {
+  assertWithinDir,
+  requireString,
+  optionalString,
+} from './read-tools.js';
+import type { ToolArgs } from './read-tools.js';
+
+/** JSON-Schema definition for a single MCP tool. */
+interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** All write tool definitions exposed by the MCP server. */
+export const WRITE_TOOLS: ToolDefinition[] = [
+  {
+    name: 'wiki_write_page',
+    description:
+      'Create or overwrite a wiki page with frontmatter and body content. Automatically updates the index.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pagePath: {
+          type: 'string',
+          description: 'Relative path within the wiki/ directory (e.g. "concepts/ai.md")',
+        },
+        title: {
+          type: 'string',
+          description: 'Page title (required)',
+        },
+        type: {
+          type: 'string',
+          description: 'Page type, e.g. "entity", "concept", "source" (required)',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional list of tags',
+        },
+        body: {
+          type: 'string',
+          description: 'Markdown body content',
+        },
+      },
+      required: ['pagePath', 'title', 'type', 'body'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'wiki_update_page',
+    description:
+      'Update an existing wiki page by merging partial frontmatter changes and/or appending or replacing body content. Updates the index if metadata changed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pagePath: {
+          type: 'string',
+          description: 'Relative path within the wiki/ directory (e.g. "concepts/ai.md")',
+        },
+        title: {
+          type: 'string',
+          description: 'New title (optional, keeps existing if omitted)',
+        },
+        type: {
+          type: 'string',
+          description: 'New type (optional, keeps existing if omitted)',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'New tags list (optional, keeps existing if omitted)',
+        },
+        bodyAppend: {
+          type: 'string',
+          description: 'Content to append to the existing body',
+        },
+        bodyReplace: {
+          type: 'string',
+          description: 'Content to replace the entire body with',
+        },
+      },
+      required: ['pagePath'],
+      additionalProperties: false,
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Validate that an optional argument, if present, is a string array. */
+function optionalStringArray(args: ToolArgs, key: string): string[] | undefined {
+  const val = args[key];
+  if (val === undefined || val === null) return undefined;
+  if (!Array.isArray(val) || !val.every((v) => typeof v === 'string')) {
+    throw new Error(`'${key}' must be an array of strings`);
+  }
+  return val as string[];
+}
+
+/**
+ * Derive a category from the page path.
+ * For paths like "concepts/ai.md" → "Concepts".
+ * For paths like "ai.md" → "General".
+ */
+function categoryFromPath(pagePath: string): string {
+  const parts = pagePath.replace(/\\/g, '/').split('/');
+  if (parts.length > 1) {
+    const dir = parts[0];
+    return dir.charAt(0).toUpperCase() + dir.slice(1);
+  }
+  return 'General';
+}
+
+/**
+ * Add or update an index entry for the given page.
+ * If an entry with the same path already exists, it is replaced.
+ */
+async function upsertIndexEntry(
+  indexPath: string,
+  entry: IndexEntry,
+): Promise<void> {
+  const entries = await readIndex(indexPath);
+  const idx = entries.findIndex((e) => e.path === entry.path);
+  if (idx >= 0) {
+    entries[idx] = entry;
+  } else {
+    entries.push(entry);
+  }
+  await writeIndex(indexPath, entries);
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler dispatch
+// ---------------------------------------------------------------------------
+
+/** Resolve a write tool call to its result text. */
+export async function handleWriteToolCall(
+  name: string,
+  args: ToolArgs,
+  wikiRoot: string,
+): Promise<string> {
+  const wikiDir = join(wikiRoot, 'wiki');
+  const indexPath = join(wikiRoot, 'wiki', 'index.md');
+
+  switch (name) {
+    case 'wiki_write_page': {
+      const pagePath = requireString(args, 'pagePath');
+      const title = requireString(args, 'title');
+      const type = requireString(args, 'type');
+      const tags = optionalStringArray(args, 'tags') ?? [];
+      const body = requireString(args, 'body');
+
+      const fullPath = assertWithinDir(wikiDir, pagePath);
+
+      await writePage(fullPath, {
+        frontmatter: { type, title, tags },
+        body,
+      });
+
+      await upsertIndexEntry(indexPath, {
+        path: pagePath,
+        title,
+        summary: '',
+        category: categoryFromPath(pagePath),
+        tags,
+      });
+
+      return JSON.stringify({
+        status: 'created',
+        path: pagePath,
+        title,
+        type,
+        tags,
+      });
+    }
+
+    case 'wiki_update_page': {
+      const pagePath = requireString(args, 'pagePath');
+      const fullPath = assertWithinDir(wikiDir, pagePath);
+
+      // Read existing page — fail gracefully if not found
+      let existing;
+      try {
+        existing = await readPage(fullPath);
+      } catch (err) {
+        if (isNotFoundError(err)) {
+          throw new Error(`Page not found: ${pagePath}`);
+        }
+        throw err;
+      }
+
+      // Merge frontmatter updates
+      const newTitle = optionalString(args, 'title');
+      const newType = optionalString(args, 'type');
+      const newTags = optionalStringArray(args, 'tags');
+
+      const mergedFrontmatter = { ...existing.frontmatter };
+      if (newTitle !== undefined) mergedFrontmatter.title = newTitle;
+      if (newType !== undefined) mergedFrontmatter.type = newType;
+      if (newTags !== undefined) mergedFrontmatter.tags = newTags;
+
+      // Handle body updates
+      const bodyAppend = optionalString(args, 'bodyAppend');
+      const bodyReplace = optionalString(args, 'bodyReplace');
+
+      let mergedBody = existing.body;
+      if (bodyReplace !== undefined) {
+        mergedBody = bodyReplace;
+      } else if (bodyAppend !== undefined) {
+        mergedBody = existing.body + '\n\n' + bodyAppend;
+      }
+
+      await writePage(fullPath, {
+        frontmatter: mergedFrontmatter,
+        body: mergedBody,
+      });
+
+      // Update index if metadata changed
+      const metadataChanged =
+        newTitle !== undefined || newType !== undefined || newTags !== undefined;
+      if (metadataChanged) {
+        await upsertIndexEntry(indexPath, {
+          path: pagePath,
+          title: (mergedFrontmatter.title as string) ?? '',
+          summary: '',
+          category: categoryFromPath(pagePath),
+          tags: (mergedFrontmatter.tags as string[]) ?? [],
+        });
+      }
+
+      return JSON.stringify({
+        status: 'updated',
+        path: pagePath,
+        frontmatter: mergedFrontmatter,
+        bodyUpdated: bodyAppend !== undefined || bodyReplace !== undefined,
+        indexUpdated: metadataChanged,
+      });
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}

--- a/tests/shared/mcp/write-tools.test.ts
+++ b/tests/shared/mcp/write-tools.test.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { handleWriteToolCall } from '../../../packages/shared/src/mcp/write-tools.js';
+import { readPage } from '../../../packages/shared/src/wiki.js';
+import { readIndex, writeIndex } from '../../../packages/shared/src/index-ops.js';
+import type { IndexEntry } from '../../../packages/shared/src/index-ops.js';
+
+let wikiRoot: string;
+let wikiDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  wikiRoot = await mkdtemp(join(tmpdir(), 'mcp-write-test-'));
+  wikiDir = join(wikiRoot, 'wiki');
+  indexPath = join(wikiDir, 'index.md');
+  await mkdir(wikiDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(wikiRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// wiki_write_page
+// ---------------------------------------------------------------------------
+
+describe('wiki_write_page', () => {
+  it('should create a new page with valid frontmatter', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'Artificial Intelligence',
+        type: 'concept',
+        tags: ['ai', 'machine-learning'],
+        body: 'AI is the simulation of human intelligence.',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('created');
+    expect(parsed.path).toBe('concepts/ai.md');
+    expect(parsed.title).toBe('Artificial Intelligence');
+    expect(parsed.type).toBe('concept');
+    expect(parsed.tags).toEqual(['ai', 'machine-learning']);
+
+    // Verify the page was actually written
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.type).toBe('concept');
+    expect(page.frontmatter.title).toBe('Artificial Intelligence');
+    expect(page.frontmatter.tags).toEqual(['ai', 'machine-learning']);
+    expect(page.body).toContain('AI is the simulation of human intelligence.');
+  });
+
+  it('should create a page without tags', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'notes/quick.md',
+        title: 'Quick Note',
+        type: 'note',
+        body: 'Just a quick note.',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('created');
+    expect(parsed.tags).toEqual([]);
+
+    const page = await readPage(join(wikiDir, 'notes', 'quick.md'));
+    expect(page.frontmatter.tags).toEqual([]);
+  });
+
+  it('should auto-update the index entry', async () => {
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'entities/turing.md',
+        title: 'Alan Turing',
+        type: 'entity',
+        tags: ['cs', 'math'],
+        body: 'Father of computer science.',
+      },
+      wikiRoot,
+    );
+
+    const entries = await readIndex(indexPath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe('entities/turing.md');
+    expect(entries[0].title).toBe('Alan Turing');
+    expect(entries[0].category).toBe('Entities');
+    expect(entries[0].tags).toEqual(['cs', 'math']);
+  });
+
+  it('should overwrite an existing page and update the index', async () => {
+    // Create initial page
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'AI',
+        type: 'concept',
+        tags: ['ai'],
+        body: 'Original content.',
+      },
+      wikiRoot,
+    );
+
+    // Overwrite
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'Artificial Intelligence',
+        type: 'concept',
+        tags: ['ai', 'ml'],
+        body: 'Updated content.',
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.title).toBe('Artificial Intelligence');
+    expect(page.body).toContain('Updated content.');
+    expect(page.body).not.toContain('Original content.');
+
+    // Index should have exactly one entry (upserted, not duplicated)
+    const entries = await readIndex(indexPath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].title).toBe('Artificial Intelligence');
+    expect(entries[0].tags).toEqual(['ai', 'ml']);
+  });
+
+  it('should block path traversal', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_write_page',
+        {
+          pagePath: '../../../etc/passwd',
+          title: 'Hack',
+          type: 'exploit',
+          body: 'malicious',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('should reject missing required title', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_write_page',
+        {
+          pagePath: 'test.md',
+          type: 'concept',
+          body: 'Some content.',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'title' must be a non-empty string");
+  });
+
+  it('should reject missing required type', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_write_page',
+        {
+          pagePath: 'test.md',
+          title: 'Test',
+          body: 'Some content.',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'type' must be a non-empty string");
+  });
+
+  it('should reject empty title', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_write_page',
+        {
+          pagePath: 'test.md',
+          title: '',
+          type: 'concept',
+          body: 'Some content.',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'title' must be a non-empty string");
+  });
+
+  it('should reject missing required body', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_write_page',
+        {
+          pagePath: 'test.md',
+          title: 'Test',
+          type: 'concept',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'body' must be a non-empty string");
+  });
+
+  it('should derive category from path directory', async () => {
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'sources/paper.md',
+        title: 'Research Paper',
+        type: 'source',
+        body: 'A research paper.',
+      },
+      wikiRoot,
+    );
+
+    const entries = await readIndex(indexPath);
+    expect(entries[0].category).toBe('Sources');
+  });
+
+  it('should use "General" category for root-level pages', async () => {
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'standalone.md',
+        title: 'Standalone Page',
+        type: 'note',
+        body: 'A standalone page.',
+      },
+      wikiRoot,
+    );
+
+    const entries = await readIndex(indexPath);
+    expect(entries[0].category).toBe('General');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wiki_update_page
+// ---------------------------------------------------------------------------
+
+describe('wiki_update_page', () => {
+  beforeEach(async () => {
+    // Create a page to update in each test
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'AI',
+        type: 'concept',
+        tags: ['ai'],
+        body: 'Artificial Intelligence overview.',
+      },
+      wikiRoot,
+    );
+  });
+
+  it('should update the title', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'Artificial Intelligence',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.frontmatter.title).toBe('Artificial Intelligence');
+    expect(parsed.indexUpdated).toBe(true);
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.title).toBe('Artificial Intelligence');
+    // Body should remain unchanged
+    expect(page.body).toContain('Artificial Intelligence overview.');
+  });
+
+  it('should update the type', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        type: 'topic',
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.type).toBe('topic');
+    // Other fields preserved
+    expect(page.frontmatter.title).toBe('AI');
+    expect(page.frontmatter.tags).toEqual(['ai']);
+  });
+
+  it('should update tags', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        tags: ['ai', 'machine-learning', 'deep-learning'],
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.tags).toEqual(['ai', 'machine-learning', 'deep-learning']);
+
+    // Index should reflect new tags
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry!.tags).toEqual(['ai', 'machine-learning', 'deep-learning']);
+  });
+
+  it('should append body content', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        bodyAppend: 'Machine learning is a subset of AI.',
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.body).toContain('Artificial Intelligence overview.');
+    expect(page.body).toContain('Machine learning is a subset of AI.');
+  });
+
+  it('should replace body content', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        bodyReplace: 'Completely new content.',
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.body).toContain('Completely new content.');
+    expect(page.body).not.toContain('Artificial Intelligence overview.');
+  });
+
+  it('should prefer bodyReplace over bodyAppend when both provided', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        bodyAppend: 'This should be ignored.',
+        bodyReplace: 'This should win.',
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.body).toContain('This should win.');
+    expect(page.body).not.toContain('This should be ignored.');
+    expect(page.body).not.toContain('Artificial Intelligence overview.');
+  });
+
+  it('should fail gracefully if page does not exist', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_update_page',
+        {
+          pagePath: 'nonexistent/page.md',
+          title: 'Ghost',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow('Page not found: nonexistent/page.md');
+  });
+
+  it('should not update index when only body is changed', async () => {
+    // Get initial index state
+    const entriesBefore = await readIndex(indexPath);
+    const entryBefore = entriesBefore.find((e) => e.path === 'concepts/ai.md');
+
+    const result = await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        bodyAppend: 'Extra content.',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.indexUpdated).toBe(false);
+
+    // Index entry should be unchanged
+    const entriesAfter = await readIndex(indexPath);
+    const entryAfter = entriesAfter.find((e) => e.path === 'concepts/ai.md');
+    expect(entryAfter!.title).toBe(entryBefore!.title);
+    expect(entryAfter!.tags).toEqual(entryBefore!.tags);
+  });
+
+  it('should update index when metadata is changed', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'Artificial Intelligence (Updated)',
+        tags: ['ai', 'updated'],
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.indexUpdated).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry!.title).toBe('Artificial Intelligence (Updated)');
+    expect(entry!.tags).toEqual(['ai', 'updated']);
+  });
+
+  it('should block path traversal', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_update_page',
+        {
+          pagePath: '../../etc/shadow',
+          title: 'Hack',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('should update multiple frontmatter fields at once', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'New Title',
+        type: 'new-type',
+        tags: ['new-tag'],
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.title).toBe('New Title');
+    expect(page.frontmatter.type).toBe('new-type');
+    expect(page.frontmatter.tags).toEqual(['new-tag']);
+  });
+
+  it('should update frontmatter and body simultaneously', async () => {
+    await handleWriteToolCall(
+      'wiki_update_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'Updated AI',
+        bodyReplace: 'Brand new body.',
+      },
+      wikiRoot,
+    );
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.frontmatter.title).toBe('Updated AI');
+    expect(page.body).toContain('Brand new body.');
+    expect(page.body).not.toContain('Artificial Intelligence overview.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown tool
+// ---------------------------------------------------------------------------
+
+describe('handleWriteToolCall — unknown tool', () => {
+  it('should throw for unknown tool names', async () => {
+    await expect(
+      handleWriteToolCall('wiki_nonexistent', {}, wikiRoot),
+    ).rejects.toThrow('Unknown tool: wiki_nonexistent');
+  });
+});


### PR DESCRIPTION
## Summary

Adds two write-capable MCP tools for page creation and updates:

### wiki_write_page
- Creates or overwrites a wiki page with validated frontmatter
- Requires: pagePath, title, type, body
- Auto-updates index entry on every write
- Path traversal guard via assertWithinDir()

### wiki_update_page
- Merges partial frontmatter updates into existing pages
- Supports bodyAppend (append) and bodyReplace (overwrite)
- Updates index only when metadata changes
- Graceful failure if page doesn't exist (ENOENT → clear error)

### Infrastructure changes
- server.ts: unified tool dispatch routing read vs write handlers
- read-tools.ts: exported helper utilities (assertWithinDir, requireString, optionalString)
- mcp/index.ts: barrel exports for write-tools

### Tests
- 14 unit tests covering create, update, overwrite, missing page, invalid input, path traversal

**Task:** c4-04 | **Plan:** cycle-4 | **Wave:** 2
**All 391 tests pass.**