### PR TITLE
feat(c4-06): cross-linking and index update MCP tools

### DIFF
--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -228,3 +228,6 @@
 - [2026-04-10T13:36:29.232Z] [commander] cycle=88 action=review-pr summary=Reviewed PR #49 (c4-03 tech debt cleanup): LGTM — regex deduplication, initWiki extraction, passWithNoTests removal, CI passing, ready to merge.
 
 - [2026-04-10T14:28:00Z] [commander] cycle=cycle-4 action=merge-pr pr=51 summary=Resolved merge conflict in activity-log.md and merged PR #51 (feat(c4-05): entity and concept creation MCP tools) via squash merge. Task c4-05 complete. 5/11 tasks done. Wave 2 tasks c4-06, c4-07 now ready.
+- [2026-04-10T14:55:10.529Z] [commander] cycle=93 action=execute-task summary=Merged PR #51 (c4-05), implemented c4-06 (crosslinks + index update MCP tools) with 16+ tests, opened PR #52.
+
+- [2026-04-10T14:58:48Z] [commander] cycle=cycle-4 action=review-pr pr=52 summary=Reviewed PR #52 (feat(c4-06): cross-linking and index update MCP tools): LGTM with 2 non-blocking nits, CI passing, no pending Copilot review. Ready to merge.

--- a/packages/shared/src/index-ops.ts
+++ b/packages/shared/src/index-ops.ts
@@ -165,6 +165,29 @@ export async function removeEntry(
 }
 
 /**
+ * Update metadata fields (summary, tags, category) for an existing index entry.
+ * Returns `true` if the entry was found and updated, `false` if not found.
+ */
+export async function updateIndexEntry(
+  filePath: string,
+  pagePath: string,
+  updates: Partial<Omit<IndexEntry, 'path'>>,
+): Promise<boolean> {
+  const entries = await readIndex(filePath);
+  const idx = entries.findIndex((e) => e.path === pagePath);
+  if (idx < 0) return false;
+
+  const entry = entries[idx];
+  if (updates.title !== undefined) entry.title = updates.title;
+  if (updates.summary !== undefined) entry.summary = updates.summary;
+  if (updates.tags !== undefined) entry.tags = updates.tags;
+  if (updates.category !== undefined) entry.category = updates.category;
+
+  await writeIndex(filePath, entries);
+  return true;
+}
+
+/**
  * Search entries by title substring and/or tags.
  * Title matching is case-insensitive. Tag matching requires at least
  * one of the provided tags to be present on the entry.
@@ -187,3 +210,4 @@ export function findEntries(
     return true;
   });
 }
+

--- a/packages/shared/src/mcp/write-tools.ts
+++ b/packages/shared/src/mcp/write-tools.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
-import { readPage, writePage, createEntityPage, createConceptPage } from '../wiki.js';
+import { readPage, writePage, createEntityPage, createConceptPage, addCrosslinks } from '../wiki.js';
 import { slugify } from '../utils.js';
-import { readIndex, writeIndex } from '../index-ops.js';
+import { readIndex, writeIndex, updateIndexEntry } from '../index-ops.js';
 import type { IndexEntry } from '../index-ops.js';
 import { isNotFoundError } from '../errors.js';
 import {
@@ -134,6 +134,56 @@ export const WRITE_TOOLS: ToolDefinition[] = [
         bodyReplace: {
           type: 'string',
           description: 'Content to replace the entire body with',
+        },
+      },
+      required: ['pagePath'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'wiki_add_crosslinks',
+    description:
+      'Add cross-reference links ("See also" section) from one wiki page to one or more target pages. Validates all target pages exist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pagePath: {
+          type: 'string',
+          description: 'Relative path of the source page within wiki/ (e.g. "concepts/ai.md")',
+        },
+        targetPages: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Array of relative paths to link to (e.g. ["entities/openai.md"])',
+        },
+      },
+      required: ['pagePath', 'targetPages'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'wiki_update_index',
+    description:
+      'Update metadata (summary, tags, category) for an existing entry in the wiki index. Returns success/failure.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pagePath: {
+          type: 'string',
+          description: 'Path of the index entry to update (e.g. "concepts/ai.md")',
+        },
+        summary: {
+          type: 'string',
+          description: 'New summary text (optional)',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'New tags list (optional)',
+        },
+        category: {
+          type: 'string',
+          description: 'New category (optional)',
         },
       },
       required: ['pagePath'],
@@ -333,6 +383,48 @@ export async function handleWriteToolCall(
         frontmatter: mergedFrontmatter,
         bodyUpdated: bodyAppend !== undefined || bodyReplace !== undefined,
         indexUpdated: metadataChanged,
+      });
+    }
+
+    case 'wiki_add_crosslinks': {
+      const pagePath = requireString(args, 'pagePath');
+      const targetPages = optionalStringArray(args, 'targetPages');
+      if (!targetPages || targetPages.length === 0) {
+        throw new Error("'targetPages' must be a non-empty array of strings");
+      }
+
+      // Validate paths stay within wiki dir
+      assertWithinDir(wikiDir, pagePath);
+      for (const tp of targetPages) {
+        assertWithinDir(wikiDir, tp);
+      }
+
+      await addCrosslinks(wikiDir, pagePath, targetPages);
+
+      return JSON.stringify({
+        status: 'updated',
+        path: pagePath,
+        crosslinks: targetPages,
+      });
+    }
+
+    case 'wiki_update_index': {
+      const pagePath = requireString(args, 'pagePath');
+      const summary = optionalString(args, 'summary');
+      const tags = optionalStringArray(args, 'tags');
+      const category = optionalString(args, 'category');
+
+      const updates: Partial<Omit<IndexEntry, 'path'>> = {};
+      if (summary !== undefined) updates.summary = summary;
+      if (tags !== undefined) updates.tags = tags;
+      if (category !== undefined) updates.category = category;
+
+      const updated = await updateIndexEntry(indexPath, pagePath, updates);
+
+      return JSON.stringify({
+        status: updated ? 'updated' : 'not_found',
+        path: pagePath,
+        fieldsUpdated: Object.keys(updates),
       });
     }
 

--- a/packages/shared/src/wiki.ts
+++ b/packages/shared/src/wiki.ts
@@ -1,6 +1,6 @@
 import matter from 'gray-matter';
 import { readFile, writeFile, readdir, stat, mkdir } from 'node:fs/promises';
-import { join, dirname, extname } from 'node:path';
+import { join, dirname, extname, relative } from 'node:path';
 import { isNotFoundError } from './errors.js';
 import { slugify } from './utils.js';
 import { addEntry } from './index-ops.js';
@@ -171,4 +171,105 @@ export async function createConceptPage(
   await addEntry(indexPath, indexEntry);
 
   return { path: relPath, indexEntry };
+}
+
+/**
+ * Append "See also" crosslinks to a wiki page.
+ * Validates all source and target pages exist, reads target titles from
+ * frontmatter, and appends (or extends) a "## See also" section with
+ * relative markdown links.  Duplicate links are silently skipped.
+ */
+export async function addCrosslinks(
+  wikiDir: string,
+  fromPage: string,
+  toPages: string[],
+): Promise<void> {
+  if (toPages.length === 0) return;
+
+  const fromFull = join(wikiDir, fromPage);
+
+  // Validate fromPage exists
+  try {
+    await stat(fromFull);
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      throw new Error(`Source page not found: ${fromPage}`);
+    }
+    throw err;
+  }
+
+  // Validate all toPages exist, collect missing
+  const missing: string[] = [];
+  for (const tp of toPages) {
+    try {
+      await stat(join(wikiDir, tp));
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        missing.push(tp);
+      } else {
+        throw err;
+      }
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`Target pages not found: ${missing.join(', ')}`);
+  }
+
+  // Read the source page
+  const page = await readPage(fromFull);
+
+  // Build link entries for each target page
+  const linkLines: string[] = [];
+  for (const tp of toPages) {
+    const toFull = join(wikiDir, tp);
+    let title: string;
+    try {
+      const targetPage = await readPage(toFull);
+      title =
+        (targetPage.frontmatter.title as string) ||
+        tp.replace(/\.md$/, '').split('/').pop()!;
+    } catch {
+      title = tp.replace(/\.md$/, '').split('/').pop()!;
+    }
+    const relLink = relative(dirname(fromFull), toFull).replace(/\\/g, '/');
+    linkLines.push(`- [${title}](${relLink})`);
+  }
+
+  // Check if "## See also" section exists
+  const seeAlsoHeader = '## See also';
+  const seeAlsoIndex = page.body.indexOf(seeAlsoHeader);
+
+  let newBody: string;
+  if (seeAlsoIndex !== -1) {
+    // Find the end of the See also section (next ## heading or end of body)
+    const afterHeader = seeAlsoIndex + seeAlsoHeader.length;
+    const nextHeadingMatch = page.body.slice(afterHeader).search(/\n## /);
+    const sectionEnd =
+      nextHeadingMatch !== -1 ? afterHeader + nextHeadingMatch : page.body.length;
+
+    // Get existing links to avoid duplicates
+    const existingSection = page.body.slice(afterHeader, sectionEnd);
+    const existingLinks = new Set(
+      existingSection
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.startsWith('- [')),
+    );
+
+    const newLinks = linkLines.filter((l) => !existingLinks.has(l));
+    if (newLinks.length === 0) return;
+
+    // Insert new links at the end of the existing section
+    const before = page.body.slice(0, sectionEnd).trimEnd();
+    const after = page.body.slice(sectionEnd);
+    newBody = before + '\n' + newLinks.join('\n') + after;
+  } else {
+    newBody =
+      page.body.trimEnd() + '\n\n' + seeAlsoHeader + '\n\n' + linkLines.join('\n');
+  }
+
+  await writePage(fromFull, {
+    frontmatter: page.frontmatter,
+    body: newBody,
+  });
 }

--- a/tests/shared/crosslinks.test.ts
+++ b/tests/shared/crosslinks.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { addCrosslinks, readPage, writePage } from '../../packages/shared/src/wiki.js';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('addCrosslinks', () => {
+  let wikiDir: string;
+
+  beforeEach(async () => {
+    wikiDir = await mkdtemp(join(tmpdir(), 'crosslinks-test-'));
+    await mkdir(join(wikiDir, 'concepts'), { recursive: true });
+    await mkdir(join(wikiDir, 'entities'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(wikiDir, { recursive: true, force: true });
+  });
+
+  it('should return early when toPages is empty', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Artificial Intelligence content.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', []);
+
+    const page = await readPage(fromPath);
+    expect(page.body).not.toContain('## See also');
+  });
+
+  it('should throw when source page does not exist', async () => {
+    await expect(
+      addCrosslinks(wikiDir, 'concepts/nonexistent.md', ['entities/openai.md']),
+    ).rejects.toThrow('Source page not found: concepts/nonexistent.md');
+  });
+
+  it('should throw listing all missing target pages', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Content.',
+    });
+
+    await expect(
+      addCrosslinks(wikiDir, 'concepts/ai.md', [
+        'entities/missing1.md',
+        'entities/missing2.md',
+      ]),
+    ).rejects.toThrow('Target pages not found: entities/missing1.md, entities/missing2.md');
+  });
+
+  it('should add See also section with correct relative links', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    const toPath = join(wikiDir, 'entities', 'openai.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Artificial Intelligence content.',
+    });
+    await writePage(toPath, {
+      frontmatter: { title: 'OpenAI' },
+      body: 'OpenAI is a company.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['entities/openai.md']);
+
+    const page = await readPage(fromPath);
+    expect(page.body).toContain('## See also');
+    expect(page.body).toContain('- [OpenAI](../entities/openai.md)');
+  });
+
+  it('should use filename as fallback title when frontmatter title is missing', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    const toPath = join(wikiDir, 'entities', 'openai.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Content.',
+    });
+    await writePage(toPath, {
+      frontmatter: {},
+      body: 'No title here.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['entities/openai.md']);
+
+    const page = await readPage(fromPath);
+    expect(page.body).toContain('- [openai](../entities/openai.md)');
+  });
+
+  it('should append to existing See also section', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    const toPath1 = join(wikiDir, 'entities', 'openai.md');
+    const toPath2 = join(wikiDir, 'entities', 'google.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Content.\n\n## See also\n\n- [OpenAI](../entities/openai.md)',
+    });
+    await writePage(toPath1, {
+      frontmatter: { title: 'OpenAI' },
+      body: 'OpenAI.',
+    });
+    await writePage(toPath2, {
+      frontmatter: { title: 'Google' },
+      body: 'Google.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['entities/google.md']);
+
+    const page = await readPage(fromPath);
+    expect(page.body).toContain('- [OpenAI](../entities/openai.md)');
+    expect(page.body).toContain('- [Google](../entities/google.md)');
+  });
+
+  it('should avoid duplicate links in existing See also section', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    const toPath = join(wikiDir, 'entities', 'openai.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Content.\n\n## See also\n\n- [OpenAI](../entities/openai.md)',
+    });
+    await writePage(toPath, {
+      frontmatter: { title: 'OpenAI' },
+      body: 'OpenAI.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['entities/openai.md']);
+
+    const page = await readPage(fromPath);
+    const matches = page.body.match(/\- \[OpenAI\]\(\.\.\/entities\/openai\.md\)/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('should handle multiple toPages at once', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'AI content.',
+    });
+    await writePage(join(wikiDir, 'entities', 'openai.md'), {
+      frontmatter: { title: 'OpenAI' },
+      body: 'OpenAI.',
+    });
+    await writePage(join(wikiDir, 'entities', 'google.md'), {
+      frontmatter: { title: 'Google' },
+      body: 'Google.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', [
+      'entities/openai.md',
+      'entities/google.md',
+    ]);
+
+    const page = await readPage(fromPath);
+    expect(page.body).toContain('## See also');
+    expect(page.body).toContain('- [OpenAI](../entities/openai.md)');
+    expect(page.body).toContain('- [Google](../entities/google.md)');
+  });
+
+  it('should handle same-directory crosslinks', async () => {
+    const fromPath = join(wikiDir, 'concepts', 'ai.md');
+    const toPath = join(wikiDir, 'concepts', 'ml.md');
+    await writePage(fromPath, {
+      frontmatter: { title: 'AI' },
+      body: 'Content.',
+    });
+    await writePage(toPath, {
+      frontmatter: { title: 'Machine Learning' },
+      body: 'ML content.',
+    });
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['concepts/ml.md']);
+
+    const page = await readPage(fromPath);
+    expect(page.body).toContain('- [Machine Learning](ml.md)');
+  });
+});

--- a/tests/shared/mcp/crosslinks-index.test.ts
+++ b/tests/shared/mcp/crosslinks-index.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { handleWriteToolCall } from '../../../packages/shared/src/mcp/write-tools.js';
+import { readPage, writePage } from '../../../packages/shared/src/wiki.js';
+import { readIndex, addEntry } from '../../../packages/shared/src/index-ops.js';
+import { addCrosslinks } from '../../../packages/shared/src/wiki.js';
+import { updateIndexEntry } from '../../../packages/shared/src/index-ops.js';
+
+let wikiRoot: string;
+let wikiDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  wikiRoot = await mkdtemp(join(tmpdir(), 'mcp-crosslinks-test-'));
+  wikiDir = join(wikiRoot, 'wiki');
+  indexPath = join(wikiDir, 'index.md');
+  await mkdir(join(wikiDir, 'concepts'), { recursive: true });
+  await mkdir(join(wikiDir, 'entities'), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(wikiRoot, { recursive: true, force: true });
+});
+
+// Helper to create a test page
+async function createTestPage(relPath: string, title: string, body: string, tags: string[] = []) {
+  const fullPath = join(wikiDir, relPath);
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  await writePage(fullPath, {
+    frontmatter: { type: 'concept', title, tags, created: '2026-01-01T00:00:00Z' },
+    body,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// addCrosslinks (unit)
+// ---------------------------------------------------------------------------
+
+describe('addCrosslinks', () => {
+  it('should add a See also section with links', async () => {
+    await createTestPage('concepts/ai.md', 'Artificial Intelligence', 'Content about AI.');
+    await createTestPage('concepts/ml.md', 'Machine Learning', 'Content about ML.');
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['concepts/ml.md']);
+
+    const page = await readPage(join(wikiDir, 'concepts/ai.md'));
+    expect(page.body).toContain('## See also');
+    expect(page.body).toContain('[Machine Learning](ml.md)');
+  });
+
+  it('should append to existing See also section', async () => {
+    await createTestPage(
+      'concepts/ai.md',
+      'Artificial Intelligence',
+      'Content.\n\n## See also\n\n- [Existing](existing.md)',
+    );
+    await createTestPage('concepts/ml.md', 'Machine Learning', 'ML content.');
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', ['concepts/ml.md']);
+
+    const page = await readPage(join(wikiDir, 'concepts/ai.md'));
+    expect(page.body).toContain('[Existing](existing.md)');
+    expect(page.body).toContain('[Machine Learning](ml.md)');
+    // Should only have one "See also" heading
+    const matches = page.body.match(/## See also/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('should throw if source page does not exist', async () => {
+    await createTestPage('concepts/ml.md', 'Machine Learning', 'ML content.');
+
+    await expect(
+      addCrosslinks(wikiDir, 'concepts/nonexistent.md', ['concepts/ml.md']),
+    ).rejects.toThrow('Source page not found');
+  });
+
+  it('should throw if target page does not exist', async () => {
+    await createTestPage('concepts/ai.md', 'AI', 'Content.');
+
+    await expect(
+      addCrosslinks(wikiDir, 'concepts/ai.md', ['concepts/nonexistent.md']),
+    ).rejects.toThrow('not found');
+  });
+
+  it('should handle multiple target pages', async () => {
+    await createTestPage('concepts/ai.md', 'AI', 'Content.');
+    await createTestPage('concepts/ml.md', 'Machine Learning', 'ML.');
+    await createTestPage('entities/openai.md', 'OpenAI', 'OpenAI entity.');
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', [
+      'concepts/ml.md',
+      'entities/openai.md',
+    ]);
+
+    const page = await readPage(join(wikiDir, 'concepts/ai.md'));
+    expect(page.body).toContain('[Machine Learning](ml.md)');
+    expect(page.body).toContain('[OpenAI](../entities/openai.md)');
+  });
+
+  it('should return early for empty toPages without modifying page', async () => {
+    await createTestPage('concepts/ai.md', 'AI', 'Content.');
+
+    await addCrosslinks(wikiDir, 'concepts/ai.md', []);
+
+    const page = await readPage(join(wikiDir, 'concepts/ai.md'));
+    expect(page.body).not.toContain('## See also');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateIndexEntry (unit)
+// ---------------------------------------------------------------------------
+
+describe('updateIndexEntry', () => {
+  it('should update summary of existing entry', async () => {
+    await addEntry(indexPath, {
+      path: 'concepts/ai.md',
+      title: 'AI',
+      summary: 'Old summary',
+      category: 'Concepts',
+      tags: ['ai'],
+    });
+
+    const result = await updateIndexEntry(indexPath, 'concepts/ai.md', {
+      summary: 'New summary about AI',
+    });
+    expect(result).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry?.summary).toBe('New summary about AI');
+  });
+
+  it('should update tags of existing entry', async () => {
+    await addEntry(indexPath, {
+      path: 'concepts/ai.md',
+      title: 'AI',
+      summary: '',
+      category: 'Concepts',
+      tags: ['old-tag'],
+    });
+
+    await updateIndexEntry(indexPath, 'concepts/ai.md', {
+      tags: ['ai', 'machine-learning'],
+    });
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry?.tags).toEqual(['ai', 'machine-learning']);
+  });
+
+  it('should update category of existing entry', async () => {
+    await addEntry(indexPath, {
+      path: 'concepts/ai.md',
+      title: 'AI',
+      summary: '',
+      category: 'Concepts',
+      tags: [],
+    });
+
+    await updateIndexEntry(indexPath, 'concepts/ai.md', {
+      category: 'Technology',
+    });
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry?.category).toBe('Technology');
+  });
+
+  it('should return false for non-existent entry', async () => {
+    const result = await updateIndexEntry(indexPath, 'concepts/nonexistent.md', {
+      summary: 'test',
+    });
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP tool: wiki_add_crosslinks
+// ---------------------------------------------------------------------------
+
+describe('wiki_add_crosslinks (via handleWriteToolCall)', () => {
+  it('should crosslink pages via MCP tool', async () => {
+    await createTestPage('concepts/ai.md', 'AI', 'AI content.');
+    await createTestPage('concepts/ml.md', 'Machine Learning', 'ML content.');
+
+    const result = await handleWriteToolCall(
+      'wiki_add_crosslinks',
+      { pagePath: 'concepts/ai.md', targetPages: ['concepts/ml.md'] },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.path).toBe('concepts/ai.md');
+    expect(parsed.crosslinks).toEqual(['concepts/ml.md']);
+  });
+
+  it('should reject empty targetPages', async () => {
+    await createTestPage('concepts/ai.md', 'AI', 'Content.');
+
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        { pagePath: 'concepts/ai.md', targetPages: [] },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'targetPages' must be a non-empty array");
+  });
+
+  it('should reject path traversal in targetPages', async () => {
+    await createTestPage('concepts/ai.md', 'AI', 'Content.');
+
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        { pagePath: 'concepts/ai.md', targetPages: ['../../etc/passwd'] },
+        wikiRoot,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP tool: wiki_update_index
+// ---------------------------------------------------------------------------
+
+describe('wiki_update_index (via handleWriteToolCall)', () => {
+  it('should update index entry via MCP tool', async () => {
+    await addEntry(indexPath, {
+      path: 'concepts/ai.md',
+      title: 'AI',
+      summary: '',
+      category: 'Concepts',
+      tags: [],
+    });
+
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      { pagePath: 'concepts/ai.md', summary: 'Covers artificial intelligence', tags: ['ai'] },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.fieldsUpdated).toContain('summary');
+    expect(parsed.fieldsUpdated).toContain('tags');
+  });
+
+  it('should return not_found for non-existent entry', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      { pagePath: 'concepts/nonexistent.md', summary: 'test' },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('not_found');
+  });
+
+  it('should return empty fieldsUpdated when no update fields provided', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      { pagePath: 'concepts/ai.md' },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.fieldsUpdated).toEqual([]);
+  });
+});

--- a/tests/shared/mcp/write-tools.test.ts
+++ b/tests/shared/mcp/write-tools.test.ts
@@ -643,6 +643,284 @@ describe('wiki_create_concept', () => {
 });
 
 // ---------------------------------------------------------------------------
+// wiki_add_crosslinks
+// ---------------------------------------------------------------------------
+
+describe('wiki_add_crosslinks', () => {
+  beforeEach(async () => {
+    // Create source and target pages
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'AI',
+        type: 'concept',
+        tags: ['ai'],
+        body: 'Artificial Intelligence overview.',
+      },
+      wikiRoot,
+    );
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'entities/openai.md',
+        title: 'OpenAI',
+        type: 'entity',
+        tags: ['company'],
+        body: 'OpenAI is an AI company.',
+      },
+      wikiRoot,
+    );
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ml.md',
+        title: 'Machine Learning',
+        type: 'concept',
+        tags: ['ml'],
+        body: 'ML is a subset of AI.',
+      },
+      wikiRoot,
+    );
+  });
+
+  it('should add crosslinks and return status updated', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_add_crosslinks',
+      {
+        pagePath: 'concepts/ai.md',
+        targetPages: ['entities/openai.md'],
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.path).toBe('concepts/ai.md');
+    expect(parsed.crosslinks).toEqual(['entities/openai.md']);
+
+    // Verify the page has a See also section
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    expect(page.body).toContain('## See also');
+    expect(page.body).toContain('entities/openai.md');
+  });
+
+  it('should add multiple crosslinks', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_add_crosslinks',
+      {
+        pagePath: 'concepts/ai.md',
+        targetPages: ['entities/openai.md', 'concepts/ml.md'],
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.crosslinks).toEqual(['entities/openai.md', 'concepts/ml.md']);
+
+    const page = await readPage(join(wikiDir, 'concepts', 'ai.md'));
+    // Links use relative paths from source page location
+    expect(page.body).toContain('openai.md');
+    expect(page.body).toContain('ml.md');
+  });
+
+  it('should reject empty targetPages', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        {
+          pagePath: 'concepts/ai.md',
+          targetPages: [],
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'targetPages' must be a non-empty array of strings");
+  });
+
+  it('should reject missing targetPages', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        {
+          pagePath: 'concepts/ai.md',
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow("'targetPages' must be a non-empty array of strings");
+  });
+
+  it('should throw when target page does not exist', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        {
+          pagePath: 'concepts/ai.md',
+          targetPages: ['entities/nonexistent.md'],
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow('Target pages not found: entities/nonexistent.md');
+  });
+
+  it('should block path traversal on pagePath', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        {
+          pagePath: '../../etc/passwd',
+          targetPages: ['entities/openai.md'],
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('should block path traversal on targetPages', async () => {
+    await expect(
+      handleWriteToolCall(
+        'wiki_add_crosslinks',
+        {
+          pagePath: 'concepts/ai.md',
+          targetPages: ['../../etc/passwd'],
+        },
+        wikiRoot,
+      ),
+    ).rejects.toThrow('Path traversal detected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wiki_update_index
+// ---------------------------------------------------------------------------
+
+describe('wiki_update_index', () => {
+  beforeEach(async () => {
+    // Create a page so there's an index entry
+    await handleWriteToolCall(
+      'wiki_write_page',
+      {
+        pagePath: 'concepts/ai.md',
+        title: 'AI',
+        type: 'concept',
+        tags: ['ai'],
+        body: 'Artificial Intelligence overview.',
+      },
+      wikiRoot,
+    );
+  });
+
+  it('should update summary in the index', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      {
+        pagePath: 'concepts/ai.md',
+        summary: 'A brief overview of AI',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.path).toBe('concepts/ai.md');
+    expect(parsed.fieldsUpdated).toContain('summary');
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry!.summary).toBe('A brief overview of AI');
+  });
+
+  it('should update tags in the index', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      {
+        pagePath: 'concepts/ai.md',
+        tags: ['ai', 'ml', 'deep-learning'],
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.fieldsUpdated).toContain('tags');
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry!.tags).toEqual(['ai', 'ml', 'deep-learning']);
+  });
+
+  it('should update category in the index', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      {
+        pagePath: 'concepts/ai.md',
+        category: 'Topics',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.fieldsUpdated).toContain('category');
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry!.category).toBe('Topics');
+  });
+
+  it('should update multiple fields at once', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      {
+        pagePath: 'concepts/ai.md',
+        summary: 'Updated summary',
+        tags: ['updated'],
+        category: 'NewCategory',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.fieldsUpdated).toEqual(expect.arrayContaining(['summary', 'tags', 'category']));
+
+    const entries = await readIndex(indexPath);
+    const entry = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(entry!.summary).toBe('Updated summary');
+    expect(entry!.tags).toEqual(['updated']);
+    expect(entry!.category).toBe('NewCategory');
+  });
+
+  it('should return not_found for non-existent entry', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      {
+        pagePath: 'nonexistent/page.md',
+        summary: 'Does not exist',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('not_found');
+    expect(parsed.path).toBe('nonexistent/page.md');
+  });
+
+  it('should return fieldsUpdated as empty array when no optional fields provided', async () => {
+    const result = await handleWriteToolCall(
+      'wiki_update_index',
+      {
+        pagePath: 'concepts/ai.md',
+      },
+      wikiRoot,
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('updated');
+    expect(parsed.fieldsUpdated).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unknown tool
 // ---------------------------------------------------------------------------
 

--- a/tests/shared/update-index-entry.test.ts
+++ b/tests/shared/update-index-entry.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  readIndex,
+  writeIndex,
+  updateIndexEntry,
+} from '../../packages/shared/src/index-ops.js';
+import type { IndexEntry } from '../../packages/shared/src/index-ops.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('updateIndexEntry', () => {
+  let tmpDir: string;
+  let indexPath: string;
+
+  const seedEntries: IndexEntry[] = [
+    {
+      path: 'entities/turing.md',
+      title: 'Alan Turing',
+      summary: 'CS pioneer',
+      category: 'Entities',
+      tags: ['cs', 'math'],
+    },
+    {
+      path: 'concepts/ai.md',
+      title: 'AI',
+      summary: 'Artificial Intelligence',
+      category: 'Concepts',
+      tags: ['ai'],
+    },
+  ];
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'update-index-test-'));
+    indexPath = join(tmpDir, 'index.md');
+    await writeIndex(indexPath, seedEntries);
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return false when entry path is not found', async () => {
+    const result = await updateIndexEntry(indexPath, 'nonexistent.md', {
+      title: 'New Title',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('should update the title of an existing entry', async () => {
+    const result = await updateIndexEntry(indexPath, 'entities/turing.md', {
+      title: 'A. M. Turing',
+    });
+    expect(result).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const updated = entries.find((e) => e.path === 'entities/turing.md');
+    expect(updated!.title).toBe('A. M. Turing');
+    expect(updated!.summary).toBe('CS pioneer');
+  });
+
+  it('should update the summary of an existing entry', async () => {
+    const result = await updateIndexEntry(indexPath, 'concepts/ai.md', {
+      summary: 'Machine intelligence overview',
+    });
+    expect(result).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const updated = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(updated!.summary).toBe('Machine intelligence overview');
+    expect(updated!.title).toBe('AI');
+  });
+
+  it('should update the category of an existing entry', async () => {
+    const result = await updateIndexEntry(indexPath, 'entities/turing.md', {
+      category: 'Historical Figures',
+    });
+    expect(result).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const updated = entries.find((e) => e.path === 'entities/turing.md');
+    expect(updated!.category).toBe('Historical Figures');
+  });
+
+  it('should update tags of an existing entry', async () => {
+    const result = await updateIndexEntry(indexPath, 'concepts/ai.md', {
+      tags: ['machine-learning', 'deep-learning'],
+    });
+    expect(result).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const updated = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(updated!.tags).toEqual(['machine-learning', 'deep-learning']);
+  });
+
+  it('should update multiple fields at once', async () => {
+    const result = await updateIndexEntry(indexPath, 'entities/turing.md', {
+      title: 'Turing, Alan',
+      summary: 'Father of computer science',
+      tags: ['computing', 'math', 'cryptography'],
+    });
+    expect(result).toBe(true);
+
+    const entries = await readIndex(indexPath);
+    const updated = entries.find((e) => e.path === 'entities/turing.md');
+    expect(updated!.title).toBe('Turing, Alan');
+    expect(updated!.summary).toBe('Father of computer science');
+    expect(updated!.tags).toEqual(['computing', 'math', 'cryptography']);
+  });
+
+  it('should not modify other entries', async () => {
+    await updateIndexEntry(indexPath, 'entities/turing.md', {
+      title: 'Updated Turing',
+    });
+
+    const entries = await readIndex(indexPath);
+    const other = entries.find((e) => e.path === 'concepts/ai.md');
+    expect(other!.title).toBe('AI');
+    expect(other!.summary).toBe('Artificial Intelligence');
+    expect(other!.tags).toEqual(['ai']);
+  });
+});


### PR DESCRIPTION
## Summary
Adds two new MCP tools for wiki cross-referencing and index management.

### Changes
- **addCrosslinks()** in wiki.ts: appends See also section with validated links, deduplicates, resolves relative paths
- **updateIndexEntry()** in index-ops.ts: partial updates to summary, tags, category of existing index entries
- **wiki_add_crosslinks** MCP tool with path traversal guards and target validation
- **wiki_update_index** MCP tool with graceful not_found handling
- 16+ new tests covering unit and MCP integration scenarios

### Task
Cycle-4, Task c4-06 (Wave 2)

All 467 tests pass. Build succeeds.