### PR TITLE
feat(c5-04): rename page operation with backlink rewriting

### DIFF
--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -1,3 +1,4 @@
+- [2026-04-10T19:08:00Z] [commander] cycle=cycle-5 action=merge-pr pr=60 summary=Merged PR #60 (feat(c5-03): MCP Resources) via squash merge. Wave 1 complete (c5-01, c5-02, c5-03). Starting wave 2 tasks.
 - [2026-04-10T19:01:00Z] [commander] cycle=cycle-5 action=execute-task task=c5-03 summary=Recovered completed c5-03 (MCP Resources) from branch — 590 tests pass, opened PR #60. Wave 1 complete (c5-01, c5-02, c5-03 done).
 - [2026-04-10T18:22:00Z] [commander] cycle=cycle-5 action=merge-pr pr=58 summary=Merged PR #58 (plan: cycle-5 -- Wiki Intelligence + Self-Healing Automation) via squash merge. Cycle-5 plan active with 14 tasks across 4 waves. Starting task c5-01 (delete page operation).
 - [2026-04-10T18:22:00Z] [commander] cycle=cycle-5 action=execute-task task=c5-01 summary=Started task c5-01 (delete page operation to shared library) — delegated to gem-orchestrator on branch task/cycle-5/c5-01.

--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -1,3 +1,4 @@
+- [2026-04-10T19:27:00Z] [commander] cycle=cycle-5 action=execute-task task=c5-04 summary=Recovered completed c5-04 (rename page with backlink rewriting) from branch — 12 unit tests, 601 pass. Opened PR #61, reviewed LGTM. CI pending.
 - [2026-04-10T19:08:00Z] [commander] cycle=cycle-5 action=merge-pr pr=60 summary=Merged PR #60 (feat(c5-03): MCP Resources) via squash merge. Wave 1 complete (c5-01, c5-02, c5-03). Starting wave 2 tasks.
 - [2026-04-10T19:01:00Z] [commander] cycle=cycle-5 action=execute-task task=c5-03 summary=Recovered completed c5-03 (MCP Resources) from branch — 590 tests pass, opened PR #60. Wave 1 complete (c5-01, c5-02, c5-03 done).
 - [2026-04-10T18:22:00Z] [commander] cycle=cycle-5 action=merge-pr pr=58 summary=Merged PR #58 (plan: cycle-5 -- Wiki Intelligence + Self-Healing Automation) via squash merge. Cycle-5 plan active with 14 tasks across 4 waves. Starting task c5-01 (delete page operation).
@@ -276,3 +277,4 @@
 
 - [2026-04-10T18:52:20Z] [commander] cycle=cycle-5 action=merge-pr pr=59 summary=Resolved merge conflict and merged PR #59 (c5-01 delete page) via squash. c5-01+c5-02 complete. Starting c5-03.
 - [2026-04-10T18:58:56.847Z] [commander] cycle=115 action=execute-task summary=Merged PR #59 (c5-01/c5-02 delete page), delegated c5-03 (MCP Resources) to gem-orchestrator on branch task/cycle-5/c5-03
+- [2026-04-10T19:24:42.166Z] [commander] cycle=116 action=execute-task summary=Recovered completed c5-03 (MCP Resources) from branch, reviewed LGTM, merged PR #60 (CI passing, 590 tests). Wave 1 complete. Delegated c5-04 (rename page) to gem-orchestrator on branch task/cycle-5/c5-04.

--- a/docs/state.json
+++ b/docs/state.json
@@ -8,7 +8,7 @@
     "c5-01": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T18:22:00Z", "completed_at": "2026-04-10T18:35:00Z", "branch": "task/cycle-5/c5-01", "pr": 59, "note": "PR #59 implemented both c5-01 and c5-02 (delete page)" },
     "c5-02": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T18:22:00Z", "completed_at": "2026-04-10T18:47:00Z", "branch": "task/cycle-5/c5-01", "pr": 59, "note": "Delivered in PR #59 alongside c5-01" },
     "c5-03": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T18:48:00Z", "completed_at": "2026-04-10T19:01:00Z", "branch": "task/cycle-5/c5-03", "pr": 60 },
-    "c5-04": { "status": "pending", "attempts": 0 },
+    "c5-04": { "status": "running", "attempts": 1, "started_at": "2026-04-10T19:08:00Z" },
     "c5-05": { "status": "pending", "attempts": 0 },
     "c5-06": { "status": "pending", "attempts": 0 },
     "c5-07": { "status": "pending", "attempts": 0 },

--- a/docs/state.json
+++ b/docs/state.json
@@ -8,7 +8,7 @@
     "c5-01": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T18:22:00Z", "completed_at": "2026-04-10T18:35:00Z", "branch": "task/cycle-5/c5-01", "pr": 59, "note": "PR #59 implemented both c5-01 and c5-02 (delete page)" },
     "c5-02": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T18:22:00Z", "completed_at": "2026-04-10T18:47:00Z", "branch": "task/cycle-5/c5-01", "pr": 59, "note": "Delivered in PR #59 alongside c5-01" },
     "c5-03": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T18:48:00Z", "completed_at": "2026-04-10T19:01:00Z", "branch": "task/cycle-5/c5-03", "pr": 60 },
-    "c5-04": { "status": "running", "attempts": 1, "started_at": "2026-04-10T19:08:00Z" },
+    "c5-04": { "status": "completed", "attempts": 1, "started_at": "2026-04-10T19:08:00Z", "completed_at": "2026-04-10T19:27:00Z", "branch": "task/cycle-5/c5-04", "pr": 61 },
     "c5-05": { "status": "pending", "attempts": 0 },
     "c5-06": { "status": "pending", "attempts": 0 },
     "c5-07": { "status": "pending", "attempts": 0 },

--- a/packages/shared/src/wiki.ts
+++ b/packages/shared/src/wiki.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile, readdir, stat, mkdir, unlink } from 'node:fs/promi
 import { join, dirname, extname, relative, resolve } from 'node:path';
 import { isNotFoundError } from './errors.js';
 import { slugify } from './utils.js';
-import { addEntry, escapeMarkdownLinkText, removeEntry } from './index-ops.js';
+import { addEntry, escapeMarkdownLinkText, readIndex, removeEntry, writeIndex } from './index-ops.js';
 import type { IndexEntry } from './index-ops.js';
 import { getBacklinks } from './backlinks.js';
 import type { BacklinkResult } from './backlinks.js';
@@ -331,4 +331,138 @@ export async function deletePage(
     deleted: true,
     backlinkWarnings,
   };
+}
+
+export interface RenameResult {
+  /** Whether the rename was successful */
+  renamed: boolean;
+  /** The old relative path */
+  oldPath: string;
+  /** The new relative path */
+  newPath: string;
+  /** Number of links that were rewritten across the wiki */
+  rewrittenLinks: number;
+  /** Relative paths of pages whose links were rewritten */
+  affectedPages: string[];
+}
+
+/**
+ * Rename (move) a wiki page from oldPath to newPath.
+ * Rewrites backlinks across the wiki, updates the index entry, and
+ * optionally updates a path-derived frontmatter title.
+ *
+ * Security: validates both paths stay within wikiDir (no path traversal).
+ */
+export async function renamePage(
+  wikiDir: string,
+  oldPath: string,
+  newPath: string,
+): Promise<RenameResult> {
+  // 1. Path traversal guard on BOTH paths
+  const resolvedBase = resolve(wikiDir).replace(/\\/g, '/');
+  const resolvedOld = resolve(wikiDir, oldPath).replace(/\\/g, '/');
+  if (!resolvedOld.startsWith(resolvedBase + '/') && resolvedOld !== resolvedBase) {
+    throw new Error('Path traversal detected — oldPath must stay within wikiDir');
+  }
+  const resolvedNew = resolve(wikiDir, newPath).replace(/\\/g, '/');
+  if (!resolvedNew.startsWith(resolvedBase + '/') && resolvedNew !== resolvedBase) {
+    throw new Error('Path traversal detected — newPath must stay within wikiDir');
+  }
+
+  // 2. Validate old page exists
+  const oldFull = join(wikiDir, oldPath);
+  try {
+    await stat(oldFull);
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      throw new Error(`Page not found: ${oldPath}`);
+    }
+    throw err;
+  }
+
+  // 3. Validate new path does NOT exist
+  const newFull = join(wikiDir, newPath);
+  try {
+    await stat(newFull);
+    throw new Error(`Target path already exists: ${newPath}`);
+  } catch (err) {
+    if (!isNotFoundError(err)) throw err;
+    // Good — file doesn't exist
+  }
+
+  // 4. Read old page content
+  const page = await readPage(oldFull);
+
+  // 5. Update frontmatter title if it was path-derived
+  const oldStem = oldPath.replace(/\.md$/, '').split('/').pop()!;
+  const newStem = newPath.replace(/\.md$/, '').split('/').pop()!;
+  if (page.frontmatter.title) {
+    const normalizedTitle = page.frontmatter.title.toLowerCase().replace(/[\s_-]+/g, '-');
+    const normalizedOldStem = oldStem.toLowerCase().replace(/[\s_-]+/g, '-');
+    if (normalizedTitle === normalizedOldStem) {
+      page.frontmatter.title = newStem.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+    }
+  }
+
+  // 6. Create parent directories + write new file
+  await writePage(newFull, page);
+
+  // 7. Scan ALL wiki pages for links to oldPath and rewrite them
+  const allPages = await listPages(wikiDir);
+  const normOld = oldPath.replace(/\\/g, '/');
+  const affectedPages: string[] = [];
+  let rewrittenLinks = 0;
+
+  for (const absPagePath of allPages) {
+    // Skip the old file itself (it's about to be deleted)
+    if (resolve(absPagePath).replace(/\\/g, '/') === resolvedOld) continue;
+    // Skip the new file (just written)
+    if (resolve(absPagePath).replace(/\\/g, '/') === resolve(newFull).replace(/\\/g, '/')) continue;
+
+    const sourcePage = await readPage(absPagePath);
+    const links = getPageLinksDetailed(sourcePage.body);
+    let modified = false;
+    let updatedBody = sourcePage.body;
+
+    for (const { text, target } of links) {
+      const sourceDir = dirname(absPagePath);
+      const resolvedAbsolute = join(sourceDir, target);
+      const resolvedRelative = relative(wikiDir, resolvedAbsolute).replace(/\\/g, '/');
+
+      if (resolvedRelative === normOld) {
+        // Compute new relative link from this source page to new location
+        const newRelLink = relative(dirname(absPagePath), newFull).replace(/\\/g, '/');
+        // Replace the exact link in body
+        const oldLink = `[${text}](${target})`;
+        const newLink = `[${text}](${newRelLink})`;
+        updatedBody = updatedBody.replace(oldLink, newLink);
+        modified = true;
+        rewrittenLinks++;
+      }
+    }
+
+    if (modified) {
+      await writePage(absPagePath, { frontmatter: sourcePage.frontmatter, body: updatedBody });
+      const relSourcePath = relative(wikiDir, absPagePath).replace(/\\/g, '/');
+      affectedPages.push(relSourcePath);
+    }
+  }
+
+  // 8. Update index entry
+  const indexPath = join(wikiDir, 'index.md');
+  const entries = await readIndex(indexPath);
+  const entryIdx = entries.findIndex((e) => e.path === oldPath);
+  if (entryIdx >= 0) {
+    entries[entryIdx].path = newPath;
+    if (page.frontmatter.title) {
+      entries[entryIdx].title = page.frontmatter.title;
+    }
+    await writeIndex(indexPath, entries);
+  }
+
+  // 9. Delete old file
+  await unlink(oldFull);
+
+  // 10. Return result
+  return { renamed: true, oldPath, newPath, rewrittenLinks, affectedPages };
 }

--- a/tests/shared/wiki-rename.test.ts
+++ b/tests/shared/wiki-rename.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renamePage, writePage, readPage, getPageLinks } from '../../packages/shared/src/wiki.js';
+import { addEntry, readIndex } from '../../packages/shared/src/index-ops.js';
+import { mkdtemp, rm, writeFile, stat, readFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('renamePage', () => {
+  let wikiDir: string;
+
+  beforeEach(async () => {
+    wikiDir = await mkdtemp(join(tmpdir(), 'wiki-rename-test-'));
+    // Seed an empty index.md so readIndex/writeIndex can read it
+    await writeFile(join(wikiDir, 'index.md'), '', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await rm(wikiDir, { recursive: true, force: true });
+  });
+
+  it('should rename a page successfully (happy path)', async () => {
+    // Arrange
+    const oldRel = 'concepts/old-page.md';
+    await writePage(join(wikiDir, oldRel), {
+      frontmatter: { title: 'Custom Title' },
+      body: 'Some content here.',
+    });
+
+    // Act
+    const result = await renamePage(wikiDir, oldRel, 'concepts/new-page.md');
+
+    // Assert: old file gone, new file exists with same content
+    await expect(stat(join(wikiDir, oldRel))).rejects.toThrow();
+    const newPage = await readPage(join(wikiDir, 'concepts/new-page.md'));
+    expect(newPage.body).toBe('Some content here.');
+    expect(result.renamed).toBe(true);
+    expect(result.oldPath).toBe(oldRel);
+    expect(result.newPath).toBe('concepts/new-page.md');
+  });
+
+  it('should rewrite a backlink in another page', async () => {
+    // Arrange: create target page and a page that links to it
+    const targetRel = 'concepts/target.md';
+    await writePage(join(wikiDir, targetRel), {
+      frontmatter: { title: 'Target' },
+      body: 'Target content.',
+    });
+    await writePage(join(wikiDir, 'linker.md'), {
+      frontmatter: { title: 'Linker' },
+      body: 'See [target](concepts/target.md) for details.',
+    });
+
+    // Act
+    const result = await renamePage(wikiDir, targetRel, 'concepts/renamed-target.md');
+
+    // Assert: linker's link now points to new path
+    const linkerPage = await readPage(join(wikiDir, 'linker.md'));
+    const links = getPageLinks(linkerPage.body);
+    expect(links).toContain('concepts/renamed-target.md');
+    expect(links).not.toContain('concepts/target.md');
+    expect(result.rewrittenLinks).toBe(1);
+    expect(result.affectedPages).toContain('linker.md');
+  });
+
+  it('should rewrite backlinks in multiple pages', async () => {
+    // Arrange: target and three pages linking to it
+    const targetRel = 'concepts/target.md';
+    await writePage(join(wikiDir, targetRel), {
+      frontmatter: { title: 'Target' },
+      body: 'Target content.',
+    });
+    await writePage(join(wikiDir, 'a.md'), {
+      frontmatter: { title: 'A' },
+      body: 'Link to [target](concepts/target.md).',
+    });
+    await writePage(join(wikiDir, 'b.md'), {
+      frontmatter: { title: 'B' },
+      body: 'Also see [target page](concepts/target.md).',
+    });
+    await writePage(join(wikiDir, 'c.md'), {
+      frontmatter: { title: 'C' },
+      body: 'Another [ref](concepts/target.md) here.',
+    });
+
+    // Act
+    const result = await renamePage(wikiDir, targetRel, 'concepts/new-target.md');
+
+    // Assert
+    expect(result.rewrittenLinks).toBe(3);
+    expect(result.affectedPages).toHaveLength(3);
+
+    for (const file of ['a.md', 'b.md', 'c.md']) {
+      const page = await readPage(join(wikiDir, file));
+      const links = getPageLinks(page.body);
+      expect(links).toContain('concepts/new-target.md');
+      expect(links).not.toContain('concepts/target.md');
+    }
+  });
+
+  it('should throw when source page does not exist', async () => {
+    await expect(
+      renamePage(wikiDir, 'does-not-exist.md', 'new-name.md'),
+    ).rejects.toThrow('Page not found: does-not-exist.md');
+  });
+
+  it('should throw when target path already exists', async () => {
+    // Arrange: create both source and target
+    await writePage(join(wikiDir, 'source.md'), {
+      frontmatter: { title: 'Source' },
+      body: 'Source content.',
+    });
+    await writePage(join(wikiDir, 'target.md'), {
+      frontmatter: { title: 'Target' },
+      body: 'Target content.',
+    });
+
+    // Act & Assert
+    await expect(
+      renamePage(wikiDir, 'source.md', 'target.md'),
+    ).rejects.toThrow('Target path already exists: target.md');
+  });
+
+  it('should reject path traversal on oldPath', async () => {
+    await expect(
+      renamePage(wikiDir, '../../etc/passwd', 'new-page.md'),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('should reject path traversal on newPath', async () => {
+    // Create a valid source page
+    await writePage(join(wikiDir, 'source.md'), {
+      frontmatter: { title: 'Source' },
+      body: 'Content.',
+    });
+
+    await expect(
+      renamePage(wikiDir, 'source.md', '../../etc/passwd'),
+    ).rejects.toThrow('Path traversal detected');
+  });
+
+  it('should handle subdirectory move and update links', async () => {
+    // Arrange: page in concepts/ and a linker at root
+    const oldRel = 'concepts/foo.md';
+    await writePage(join(wikiDir, oldRel), {
+      frontmatter: { title: 'Foo' },
+      body: 'Foo content.',
+    });
+    await writePage(join(wikiDir, 'linker.md'), {
+      frontmatter: { title: 'Linker' },
+      body: 'See [foo](concepts/foo.md).',
+    });
+
+    // Act: move to entities/
+    const result = await renamePage(wikiDir, oldRel, 'entities/foo.md');
+
+    // Assert: file moved
+    await expect(stat(join(wikiDir, oldRel))).rejects.toThrow();
+    const movedPage = await readPage(join(wikiDir, 'entities/foo.md'));
+    expect(movedPage.body).toBe('Foo content.');
+
+    // Assert: linker updated
+    const linkerPage = await readPage(join(wikiDir, 'linker.md'));
+    const links = getPageLinks(linkerPage.body);
+    expect(links).toContain('entities/foo.md');
+    expect(links).not.toContain('concepts/foo.md');
+    expect(result.rewrittenLinks).toBe(1);
+  });
+
+  it('should update the index entry to the new path', async () => {
+    // Arrange
+    const oldRel = 'entities/old-entity.md';
+    await writePage(join(wikiDir, oldRel), {
+      frontmatter: { title: 'Custom Title' },
+      body: 'Entity content.',
+    });
+    await addEntry(join(wikiDir, 'index.md'), {
+      path: oldRel,
+      title: 'Custom Title',
+      summary: 'An entity',
+      category: 'Entities',
+      tags: ['test'],
+    });
+
+    // Verify index has old entry
+    const before = await readIndex(join(wikiDir, 'index.md'));
+    expect(before.find((e) => e.path === oldRel)).toBeDefined();
+
+    // Act
+    const newRel = 'entities/new-entity.md';
+    await renamePage(wikiDir, oldRel, newRel);
+
+    // Assert: index entry updated
+    const after = await readIndex(join(wikiDir, 'index.md'));
+    expect(after.find((e) => e.path === oldRel)).toBeUndefined();
+    expect(after.find((e) => e.path === newRel)).toBeDefined();
+  });
+
+  it('should create parent directories for the new path', async () => {
+    // Arrange: page at root
+    await writePage(join(wikiDir, 'page.md'), {
+      frontmatter: { title: 'Page' },
+      body: 'Content.',
+    });
+
+    // Act: move to a deeply nested non-existent directory
+    await renamePage(wikiDir, 'page.md', 'deep/nested/dir/page.md');
+
+    // Assert: new file exists
+    const newPage = await readPage(join(wikiDir, 'deep/nested/dir/page.md'));
+    expect(newPage.body).toBe('Content.');
+  });
+
+  it('should update frontmatter title when path-derived', async () => {
+    // Arrange: title matches the old filename stem
+    await writePage(join(wikiDir, 'old-name.md'), {
+      frontmatter: { title: 'Old Name' },
+      body: 'Content.',
+    });
+
+    // Act
+    await renamePage(wikiDir, 'old-name.md', 'new-name.md');
+
+    // Assert: title derived from new stem
+    const page = await readPage(join(wikiDir, 'new-name.md'));
+    expect(page.frontmatter.title).toBe('New Name');
+  });
+
+  it('should preserve frontmatter title when NOT path-derived', async () => {
+    // Arrange: title does NOT match the filename stem
+    await writePage(join(wikiDir, 'old-name.md'), {
+      frontmatter: { title: 'Completely Different Title' },
+      body: 'Content.',
+    });
+
+    // Act
+    await renamePage(wikiDir, 'old-name.md', 'new-name.md');
+
+    // Assert: title unchanged
+    const page = await readPage(join(wikiDir, 'new-name.md'));
+    expect(page.frontmatter.title).toBe('Completely Different Title');
+  });
+
+  it('should return correct result shape', async () => {
+    // Arrange
+    const oldRel = 'concepts/target.md';
+    await writePage(join(wikiDir, oldRel), {
+      frontmatter: { title: 'Target' },
+      body: 'Content.',
+    });
+    await writePage(join(wikiDir, 'linker.md'), {
+      frontmatter: { title: 'Linker' },
+      body: 'See [target](concepts/target.md).',
+    });
+
+    // Act
+    const result = await renamePage(wikiDir, oldRel, 'concepts/moved.md');
+
+    // Assert result shape
+    expect(result).toEqual({
+      renamed: true,
+      oldPath: oldRel,
+      newPath: 'concepts/moved.md',
+      rewrittenLinks: 1,
+      affectedPages: ['linker.md'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds renamePage() to the shared library with full backlink rewriting support.

## Changes
- **renamePage(wikiDir, oldPath, newPath)** in packages/shared/src/wiki.ts
  - Path traversal guard on both old and new paths
  - Validates old page exists, new path does not
  - Creates parent directories for newPath if needed
  - Rewrites backlinks across all wiki pages
  - Updates index entry (old path → new path)
  - Updates path-derived frontmatter title
  - Returns RenameResult with affected pages list
- **12 unit tests** in tests/shared/wiki-rename.test.ts
  - Happy path, backlink rewriting, index update
  - Path traversal rejection, rename to existing path
  - Edge cases: no backlinks, cross-directory moves

## Task
Cycle-5 task c5-04 (wave 2, depends on c5-02 ✅)

All 601 tests pass (2 pre-existing EBUSY flaky failures on Windows temp cleanup).